### PR TITLE
feat(settings): RangeSlider for Lab thresholds (closes #36)

### DIFF
--- a/src/components/RangeSlider.tsx
+++ b/src/components/RangeSlider.tsx
@@ -1,0 +1,118 @@
+import { useEffect, useRef, useState } from 'react'
+
+export interface RangeSliderProps {
+  value: number
+  onChange: (next: number) => void
+  min?: number
+  max?: number
+  step?: number
+  unitLabel?: string
+  ariaLabel: string
+  debounceMs?: number
+}
+
+export default function RangeSlider({
+  value,
+  onChange,
+  min = 0,
+  max = 365,
+  step = 1,
+  unitLabel = '',
+  ariaLabel,
+  debounceMs = 500,
+}: RangeSliderProps) {
+  const [draft, setDraft] = useState<number>(value)
+  const timerRef = useRef<number | null>(null)
+
+  useEffect(() => { setDraft(value) }, [value])
+
+  useEffect(() => () => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+  }, [])
+
+  const commit = (n: number) => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current)
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null
+      if (n !== value) onChange(n)
+    }, debounceMs)
+  }
+
+  const handleChange = (raw: string) => {
+    const n = Math.max(min, Math.min(max, Math.round(Number(raw))))
+    setDraft(n)
+    commit(n)
+  }
+
+  const pct = max === min ? 0 : ((draft - min) / (max - min)) * 100
+
+  return (
+    <div className="flex items-center gap-3" style={{ width: '100%', maxWidth: 420 }}>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={draft}
+        onChange={(e) => handleChange(e.target.value)}
+        aria-label={ariaLabel}
+        aria-valuenow={draft}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        className="range-slider"
+        style={{
+          flex: 1,
+          height: 4,
+          appearance: 'none',
+          WebkitAppearance: 'none',
+          background: `linear-gradient(to right, var(--teal) 0%, var(--teal) ${pct}%, var(--border-subtle) ${pct}%, var(--border-subtle) 100%)`,
+          borderRadius: 'var(--radius-full)',
+          outline: 'none',
+          cursor: 'pointer',
+        }}
+      />
+      <span
+        aria-hidden="true"
+        style={{
+          minWidth: 56,
+          textAlign: 'right',
+          fontFamily: 'var(--font-sans)',
+          fontWeight: 500,
+          fontSize: 13,
+          color: 'var(--ink)',
+          fontVariantNumeric: 'tabular-nums',
+        }}
+      >
+        {draft}
+        {unitLabel && <span style={{ marginLeft: 4, color: 'var(--slate)', fontWeight: 400 }}>{unitLabel}</span>}
+      </span>
+      <style>{`
+        .range-slider::-webkit-slider-thumb {
+          -webkit-appearance: none;
+          appearance: none;
+          width: 16px;
+          height: 16px;
+          border-radius: var(--radius-full);
+          background: var(--teal);
+          border: 2px solid var(--cream);
+          box-shadow: 0 0 0 1px var(--teal);
+          cursor: pointer;
+          transition: transform 120ms ease-out;
+        }
+        .range-slider::-webkit-slider-thumb:hover { transform: scale(1.15); }
+        .range-slider::-moz-range-thumb {
+          width: 14px;
+          height: 14px;
+          border-radius: var(--radius-full);
+          background: var(--teal);
+          border: 2px solid var(--cream);
+          box-shadow: 0 0 0 1px var(--teal);
+          cursor: pointer;
+        }
+        .range-slider:focus-visible {
+          box-shadow: 0 0 0 3px color-mix(in oklch, var(--teal) 35%, transparent);
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/pages/portal/SettingsPage.tsx
+++ b/src/pages/portal/SettingsPage.tsx
@@ -15,6 +15,7 @@ import Avatar from '../../components/Avatar'
 import InlineSelect from '../../components/InlineSelect'
 import { getPersonInfo } from '../../data/team'
 import { useLabPrefs } from '../../hooks/useLabPrefs'
+import RangeSlider from '../../components/RangeSlider'
 
 interface WorkflowTemplate {
   id: string
@@ -615,12 +616,6 @@ function SettingsSection({ title, subtitle, icon: Icon, children }: { title: str
 
 function LabPrefsPanel() {
   const { prefs, update, reset, defaults } = useLabPrefs()
-  const [review, setReview] = useState<string>(String(prefs.manuscriptsReviewDays))
-  const [stale, setStale] = useState<string>(String(prefs.manuscriptsStaleDays))
-  useEffect(() => { setReview(String(prefs.manuscriptsReviewDays)); setStale(String(prefs.manuscriptsStaleDays)) }, [prefs])
-
-  const commitReview = () => update({ manuscriptsReviewDays: parseInt(review, 10) })
-  const commitStale = () => update({ manuscriptsStaleDays: parseInt(stale, 10) })
 
   return (
     <div className="flex flex-col gap-4">
@@ -628,48 +623,28 @@ function LabPrefsPanel() {
         label="Awaiting your review — flag after"
         hint={`Reviewer comments assigned to you that stay pending past this many days surface as "Awaiting your review". Default ${defaults.manuscriptsReviewDays}d.`}
       >
-        <div className="flex items-center gap-2">
-          <input
-            type="number"
-            min={0}
-            max={365}
-            value={review}
-            onChange={(e) => setReview(e.target.value)}
-            onBlur={commitReview}
-            onKeyDown={(e) => { if (e.key === 'Enter') { (e.target as HTMLInputElement).blur() } }}
-            aria-label="Awaiting review threshold in days"
-            style={{
-              width: 80, padding: '6px 10px', fontSize: '13px',
-              background: 'var(--cream)', border: '1px solid var(--border-subtle)',
-              borderRadius: 'var(--radius-md)', color: 'var(--ink)',
-            }}
-          />
-          <span style={{ fontSize: '12px', color: 'var(--slate)' }}>days</span>
-        </div>
+        <RangeSlider
+          value={prefs.manuscriptsReviewDays}
+          onChange={(n) => update({ manuscriptsReviewDays: n })}
+          min={0}
+          max={365}
+          unitLabel="days"
+          ariaLabel="Awaiting review threshold in days"
+        />
       </SettingsField>
 
       <SettingsField
         label="Stale drafts — flag after"
         hint={`Publications in "In Preparation" with no activity for this many days surface as "Stale drafts". Default ${defaults.manuscriptsStaleDays}d.`}
       >
-        <div className="flex items-center gap-2">
-          <input
-            type="number"
-            min={0}
-            max={365}
-            value={stale}
-            onChange={(e) => setStale(e.target.value)}
-            onBlur={commitStale}
-            onKeyDown={(e) => { if (e.key === 'Enter') { (e.target as HTMLInputElement).blur() } }}
-            aria-label="Stale drafts threshold in days"
-            style={{
-              width: 80, padding: '6px 10px', fontSize: '13px',
-              background: 'var(--cream)', border: '1px solid var(--border-subtle)',
-              borderRadius: 'var(--radius-md)', color: 'var(--ink)',
-            }}
-          />
-          <span style={{ fontSize: '12px', color: 'var(--slate)' }}>days</span>
-        </div>
+        <RangeSlider
+          value={prefs.manuscriptsStaleDays}
+          onChange={(n) => update({ manuscriptsStaleDays: n })}
+          min={0}
+          max={365}
+          unitLabel="days"
+          ariaLabel="Stale drafts threshold in days"
+        />
       </SettingsField>
 
       <div>


### PR DESCRIPTION
Closes #36.

Replaces the two number inputs in `LabPrefsPanel` with a reusable `<RangeSlider>` primitive. Reads/writes `useLabPrefs()`, 500ms debounce on commit, range 0-365, snaps to integers. Live readout to right (DM Sans 500, `tabular-nums`). Teal fill track + cream-bordered teal thumb. Focus ring uses 35% teal mix.

Skipped issue's speculative `critical_value_threshold` slider — issue text marked it 'TBD — possibly tied to manuscript priority' and the underlying field doesn't exist on manuscripts yet.

Source: Stitch consultant batch 2026-04-26 mockup #04. Build clean.