### PR TITLE
feat(hermes): citation pills + Operation Findings callout (closes #38)

### DIFF
--- a/src/components/HermesResponse.tsx
+++ b/src/components/HermesResponse.tsx
@@ -1,0 +1,196 @@
+import { Link } from 'react-router-dom'
+import { ExternalLink } from 'lucide-react'
+import { PATHS } from '../constants/paths'
+
+export type HermesCitation =
+  | { type: 'project'; slug: string; title: string }
+  | { type: 'publication'; slug?: string; title: string; url?: string }
+  | { type: 'task'; id: string; title: string }
+  | { type: 'meeting'; id: string; title: string }
+
+export interface HermesFinding {
+  value: string
+  label: string
+  detail?: string
+}
+
+interface ParsedHermes {
+  prose: string
+  citations: HermesCitation[]
+  findings: HermesFinding[]
+}
+
+const FENCE_PATTERN = /\n*```hermes\s*\n([\s\S]*?)\n```\s*$/
+
+export function parseHermesContent(raw: string): ParsedHermes {
+  const match = raw.match(FENCE_PATTERN)
+  if (!match) return { prose: raw, citations: [], findings: [] }
+
+  try {
+    const parsed = JSON.parse(match[1]) as { citations?: unknown; findings?: unknown }
+    const citations = Array.isArray(parsed.citations) ? (parsed.citations as HermesCitation[]) : []
+    const findings = Array.isArray(parsed.findings) ? (parsed.findings as HermesFinding[]) : []
+    return {
+      prose: raw.replace(FENCE_PATTERN, '').trimEnd(),
+      citations,
+      findings,
+    }
+  } catch {
+    return { prose: raw, citations: [], findings: [] }
+  }
+}
+
+function citationHref(c: HermesCitation): string | null {
+  if (c.type === 'project' && c.slug) return PATHS.project(c.slug)
+  if (c.type === 'task' && c.id) return `${PATHS.tasks}?focus=${encodeURIComponent(c.id)}`
+  if (c.type === 'meeting' && c.id) return PATHS.meeting(c.id)
+  if (c.type === 'publication') {
+    if (c.url) return c.url
+    if (c.slug) return `/publications#${encodeURIComponent(c.slug)}`
+  }
+  return null
+}
+
+export default function HermesResponse({ content }: { content: string }) {
+  const { prose, citations, findings } = parseHermesContent(content)
+
+  return (
+    <div className="flex flex-col" style={{ gap: 10 }}>
+      <p
+        className="text-sm leading-relaxed"
+        style={{ color: 'var(--ink)', margin: 0, whiteSpace: 'pre-wrap' }}
+      >
+        {prose}
+      </p>
+
+      {findings.length > 0 && (
+        <div className="flex flex-col" style={{ gap: 6 }}>
+          {findings.map((f, i) => (
+            <div
+              key={i}
+              role="note"
+              aria-label={`Operation finding: ${f.value} ${f.label}`}
+              style={{
+                borderRadius: 'var(--radius-lg)',
+                border: '1px solid var(--gold)',
+                background: 'var(--gold-emphasis)',
+                padding: 'var(--sp-sm) var(--sp-md)',
+                display: 'flex',
+                flexDirection: 'column',
+                gap: 4,
+              }}
+            >
+              <span
+                style={{
+                  fontSize: '10px',
+                  fontWeight: 600,
+                  letterSpacing: '0.08em',
+                  textTransform: 'uppercase',
+                  color: 'var(--gold-on-emphasis)',
+                  opacity: 0.85,
+                }}
+              >
+                Operation Findings
+              </span>
+              <div className="flex items-baseline" style={{ gap: 8, flexWrap: 'wrap' }}>
+                <span
+                  style={{
+                    fontFamily: 'var(--font-sans)',
+                    fontWeight: 700,
+                    fontSize: 22,
+                    color: 'var(--gold-on-emphasis)',
+                    fontVariantNumeric: 'tabular-nums',
+                    lineHeight: 1.1,
+                  }}
+                >
+                  {f.value}
+                </span>
+                <span
+                  style={{
+                    fontSize: 13,
+                    color: 'var(--ink)',
+                    lineHeight: 1.4,
+                  }}
+                >
+                  {f.label}
+                </span>
+              </div>
+              {f.detail && (
+                <p style={{ margin: 0, fontSize: 12, color: 'var(--slate)', lineHeight: 1.5 }}>
+                  {f.detail}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {citations.length > 0 && (
+        <div
+          aria-label="Sources"
+          className="flex flex-wrap items-center"
+          style={{ gap: 6, marginTop: 2 }}
+        >
+          <span
+            style={{
+              fontSize: 10,
+              fontWeight: 500,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: 'var(--slate)',
+              opacity: 0.7,
+              marginRight: 2,
+            }}
+          >
+            Sources
+          </span>
+          {citations.map((c, i) => {
+            const href = citationHref(c)
+            const inner = (
+              <>
+                <span style={{ opacity: 0.85 }}>{c.type}</span>
+                <span style={{ color: 'var(--ink)', fontWeight: 500 }}>{c.title}</span>
+                {c.type === 'publication' && c.url && <ExternalLink size={10} aria-hidden="true" />}
+              </>
+            )
+            const pillStyle: React.CSSProperties = {
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              padding: '3px 10px',
+              borderRadius: 'var(--radius-full)',
+              fontSize: 11,
+              border: '1px solid var(--border-subtle)',
+              background: 'var(--cream)',
+              color: 'var(--slate)',
+              textDecoration: 'none',
+              maxWidth: 240,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+            }
+            if (!href) {
+              return (
+                <span key={i} style={pillStyle}>
+                  {inner}
+                </span>
+              )
+            }
+            if (href.startsWith('http')) {
+              return (
+                <a key={i} href={href} target="_blank" rel="noopener noreferrer" style={pillStyle}>
+                  {inner}
+                </a>
+              )
+            }
+            return (
+              <Link key={i} to={href} style={pillStyle}>
+                {inner}
+              </Link>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ProjectComments.tsx
+++ b/src/components/ProjectComments.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { MessageSquare, Send } from 'lucide-react'
 import HermesMark from './HermesMark'
+import HermesResponse from './HermesResponse'
 import { useComments } from '../hooks/useApiData'
 import { useAddComment } from '../hooks/useMutations'
 import { useAuth } from '../hooks/useAuth'
@@ -200,16 +201,7 @@ export default function ProjectComments({ projectSlug }: Props) {
                               {formatRelativeTime(comment.created_at)}
                             </span>
                           </div>
-                          <p
-                            style={{
-                              fontSize: 'var(--value-size)',
-                              color: 'var(--ink)',
-                              lineHeight: 1.5,
-                              margin: 0,
-                            }}
-                          >
-                            {comment.content}
-                          </p>
+                          <HermesResponse content={comment.content} />
                         </div>
                         <ReactionBar targetType="comment" targetId={comment.id} />
                       </div>

--- a/src/components/tasks/detail/TaskComments.tsx
+++ b/src/components/tasks/detail/TaskComments.tsx
@@ -4,6 +4,7 @@ import {
   MessageSquare, Send, Scale,
 } from 'lucide-react'
 import Avatar from '../../Avatar'
+import HermesResponse from '../../HermesResponse'
 import ReactionBar from '../../ReactionBar'
 import { getPersonInfo } from '../../../data/team'
 import { useDecisions } from '../../../hooks/useApiData'
@@ -98,7 +99,11 @@ export function TaskComments({ taskId, taskTitle, projectSlug }: { taskId: strin
                   <span className="text-xs font-medium" style={{ color: 'var(--ink)' }}>{person.name}</span>
                   <span className="text-[10px]" style={{ color: 'var(--slate)', opacity: 'var(--ink-hint)' }}>{formatRelativeTime(c.created_at)}</span>
                 </div>
-                <p className="text-sm mt-0.5" style={{ color: 'var(--ink)', whiteSpace: 'pre-wrap' }}>{c.content}</p>
+                {c.author_slug === 'claude-ai' ? (
+                  <div className="mt-0.5"><HermesResponse content={c.content} /></div>
+                ) : (
+                  <p className="text-sm mt-0.5" style={{ color: 'var(--ink)', whiteSpace: 'pre-wrap' }}>{c.content}</p>
+                )}
                 <ReactionBar targetType="task_comment" targetId={c.id} compact />
               </div>
             </div>

--- a/src/pages/portal/AskTheLab.tsx
+++ b/src/pages/portal/AskTheLab.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { HelpCircle, Plus, X, MessageSquare, Check, ChevronDown, ChevronUp, Send, Sparkles, Search } from 'lucide-react'
+import { HelpCircle, Plus, X, MessageSquare, Check, ChevronDown, ChevronUp, Send, Search } from 'lucide-react'
+import HermesMark from '../../components/HermesMark'
+import HermesResponse from '../../components/HermesResponse'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CardSkeleton } from '../../components/LoadingSkeleton'
 import PageHeader from '../../components/PageHeader'
@@ -316,17 +318,15 @@ function QuestionExpanded({ questionId }: { questionId: string }) {
                   }}
                 >
                   <div className="flex items-center gap-1.5 mb-1">
-                    <Sparkles size={12} style={{ color: 'var(--gold)' }} />
-                    <span style={{ fontSize: '10px', color: 'var(--gold)' }}>
+                    <HermesMark size={14} variant="avatar" />
+                    <span style={{ fontSize: '10px', color: 'var(--gold)', fontWeight: 500 }}>
                       Hermes
                     </span>
                     <span className="ml-auto" style={{ fontSize: '10px', color: 'var(--slate)', opacity: 0.75 }}>
                       {formatRelativeTime(answer.created_at)}
                     </span>
                   </div>
-                  <p className="text-sm leading-relaxed" style={{ color: 'var(--ink)', margin: 0 }}>
-                    {answer.content}
-                  </p>
+                  <HermesResponse content={answer.content} />
                 </div>
               )
             }


### PR DESCRIPTION
Closes #38.

Adds `<HermesResponse>` that parses an optional trailing fenced ````hermes JSON block carrying `{ citations, findings }` and renders:

- **Operation Findings callout** — gold-bordered card with bolded value (`tabular-nums`, 22px) + label + optional detail line. Uses `--gold-on-emphasis` token per Rule 42.
- **Source pills** below the response — clickable, route to project/task/meeting/publication via `PATHS`. Plain prose with no JSON tail renders cleanly (no breakage of existing Hermes replies).

Wired into 3 surfaces: AskTheLab answers, ProjectComments, task-detail TaskComments. AskTheLab also swapped lucide `Sparkles` → `HermesMark` per CLAUDE.md Rule 29.

**Follow-up (PB repo):** `hub_ai_listener.py` prompt needs the structured-tail spec to actually emit fenced JSON. Frontend degrades gracefully until then — no regression of existing prose responses.

Source: Stitch consultant batch 2026-04-26 mockup #12. Build clean.