### PR TITLE
feat(insights): /portal/insights operational dashboard (closes #37)

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -26,7 +26,7 @@ import { handleActivity, handleActivityHeatmap } from './routes/activity';
 import { handleGetSubtasks, handleCreateSubtask, handleToggleSubtask, handleDeleteSubtask, handleReorderSubtasks } from './routes/subtasks';
 import { handleTeamPulse } from './routes/team-pulse';
 import { handleGetPaperLinks, handleLinkPaper, handleUnlinkPaper, handlePapersByProject, handlePapersByPublication } from './routes/paper-links';
-import { handleInsightConnections, handleInsightSuggestions } from './routes/insights';
+import { handleInsightConnections, handleInsightSuggestions, handleInsightsDashboard } from './routes/insights';
 import { handleGetDependencies, handleGetProjectDependencies, handleCreateDependency, handleDeleteDependency } from './routes/dependencies';
 import { handleTrajectory } from './routes/trajectory';
 import { handleContributions } from './routes/contributions';
@@ -320,6 +320,10 @@ app.get('/api/digest/:id/comments', (c) => handleGetDigestComments(c.req.param('
 // ─────────────────────────────────────────────────────────────────────────────
 app.get('/api/insights/connections', (c) => handleInsightConnections(E(c)));
 app.get('/api/insights/suggestions', (c) => handleInsightSuggestions(U(c), E(c)));
+app.get('/api/insights/dashboard', async (c) => {
+  if (!(await isPiRequest(c.req.raw, E(c)))) return error('Forbidden — PI access only', 403);
+  return handleInsightsDashboard(E(c));
+});
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Papers

--- a/api/routes/insights.ts
+++ b/api/routes/insights.ts
@@ -237,3 +237,188 @@ export async function handleInsightSuggestions(url: URL, env: Env): Promise<Resp
     count: related.length,
   })
 }
+
+// ── /api/insights/dashboard — operational insights (PI-only) ──
+// GH #37 EPIC. All queries hit existing tables — no schema change.
+
+interface DashboardMetrics {
+  stalledProjects: { count: number; deltaWoW: number }
+  tasksPerPerson: { avg: number; total: number; distribution: { slug: string; count: number }[] }
+  manuscriptsInRevision: { count: number; awaitingReplyOver7d: number }
+  grantsInPipeline: { count: number; daysToNextDeadline: number | null }
+}
+
+interface DashboardResponse {
+  week: string
+  metrics: DashboardMetrics
+  workloadHeatmap: { slug: string; days: { mon: number; tue: number; wed: number; thu: number; fri: number } }[]
+  pipelineFunnel: { stage: string; count: number }[]
+  velocityScatter: { slug: string; title: string; daysSinceUpdate: number; openTasks: number; isOutlier: boolean }[]
+  stalledRegistry: { slug: string; title: string; daysIdle: number; openTasks: number }[]
+}
+
+function isoWeek(d: Date): string {
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+  const dayNum = date.getUTCDay() || 7
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum)
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
+  const weekNum = Math.ceil((((date.getTime() - yearStart.getTime()) / 86400000) + 1) / 7)
+  return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`
+}
+
+const STALL_THRESHOLD_DAYS = 14
+const SCATTER_OUTLIER_DAYS = 30
+const SCATTER_OUTLIER_TASKS = 10
+
+export async function handleInsightsDashboard(env: Env): Promise<Response> {
+  const week = isoWeek(new Date())
+
+  // 1. Stalled projects (no project_updates in 14d), with WoW delta
+  const stalledNow = await env.DB.prepare(
+    `SELECT COUNT(*) as c FROM projects p
+     WHERE p.deleted_at IS NULL AND p.status = 'active'
+       AND NOT EXISTS (
+         SELECT 1 FROM project_updates pu
+         WHERE pu.project_id = p.id AND pu.created_at > datetime('now', '-${STALL_THRESHOLD_DAYS} days')
+       )`
+  ).first<{ c: number }>()
+
+  const stalledLast = await env.DB.prepare(
+    `SELECT COUNT(*) as c FROM projects p
+     WHERE p.deleted_at IS NULL AND p.status = 'active'
+       AND NOT EXISTS (
+         SELECT 1 FROM project_updates pu
+         WHERE pu.project_id = p.id
+           AND pu.created_at > datetime('now', '-${STALL_THRESHOLD_DAYS + 7} days')
+           AND pu.created_at <= datetime('now', '-7 days')
+       )`
+  ).first<{ c: number }>()
+
+  // 2. Tasks per person (open only)
+  const taskDistRes = await env.DB.prepare(
+    `SELECT assignee, COUNT(*) as c FROM tasks
+     WHERE deleted_at IS NULL AND completed = 0 AND assignee IS NOT NULL
+     GROUP BY assignee ORDER BY c DESC`
+  ).all<{ assignee: string; c: number }>()
+  const distribution = (taskDistRes.results ?? []).map((r) => ({ slug: r.assignee, count: r.c }))
+  const totalOpen = distribution.reduce((s, r) => s + r.count, 0)
+  const memberCountRes = await env.DB.prepare(
+    `SELECT COUNT(*) as c FROM team_members WHERE active = 1`
+  ).first<{ c: number }>()
+  const memberCount = Math.max(1, memberCountRes?.c ?? 1)
+  const avg = Math.round((totalOpen / memberCount) * 10) / 10
+
+  // 3. Manuscripts in revision (projects whose stage = 'Revisions' or has a manuscript_revisions row open)
+  const msRevRes = await env.DB.prepare(
+    `SELECT COUNT(*) as c FROM projects
+     WHERE deleted_at IS NULL AND stage IN ('Revisions', 'Review')`
+  ).first<{ c: number }>()
+  const msAwaitingRes = await env.DB.prepare(
+    `SELECT COUNT(*) as c FROM manuscript_revisions
+     WHERE status = 'awaiting_response'
+       AND received_at < datetime('now', '-7 days')`
+  ).first<{ c: number }>().catch(() => ({ c: 0 } as { c: number }))
+
+  // 4. Grants pipeline + days to next deadline
+  const grantsRes = await env.DB.prepare(
+    `SELECT COUNT(*) as c FROM nih_grants
+     WHERE status NOT IN ('funded', 'withdrawn', 'rejected')`
+  ).first<{ c: number }>().catch(() => ({ c: 0 } as { c: number }))
+  const nextDeadlineRes = await env.DB.prepare(
+    `SELECT julianday(deadline) - julianday('now') as d FROM nih_grants
+     WHERE deadline IS NOT NULL AND deadline > date('now')
+     ORDER BY deadline ASC LIMIT 1`
+  ).first<{ d: number }>().catch(() => null)
+  const daysToNextDeadline = nextDeadlineRes ? Math.max(0, Math.round(nextDeadlineRes.d)) : null
+
+  // 5. Workload heatmap — tasks due this week, grouped by assignee × weekday
+  const heatmapRes = await env.DB.prepare(
+    `SELECT assignee,
+       CAST(strftime('%w', due_date) AS INT) as dow,
+       COUNT(*) as c
+     FROM tasks
+     WHERE deleted_at IS NULL AND completed = 0 AND assignee IS NOT NULL
+       AND due_date IS NOT NULL
+       AND due_date >= date('now', 'weekday 1', '-7 days')
+       AND due_date < date('now', 'weekday 1')
+     GROUP BY assignee, dow`
+  ).all<{ assignee: string; dow: number; c: number }>()
+
+  const heatmapMap = new Map<string, { mon: number; tue: number; wed: number; thu: number; fri: number }>()
+  for (const r of heatmapRes.results ?? []) {
+    const cur = heatmapMap.get(r.assignee) ?? { mon: 0, tue: 0, wed: 0, thu: 0, fri: 0 }
+    if (r.dow === 1) cur.mon = r.c
+    else if (r.dow === 2) cur.tue = r.c
+    else if (r.dow === 3) cur.wed = r.c
+    else if (r.dow === 4) cur.thu = r.c
+    else if (r.dow === 5) cur.fri = r.c
+    heatmapMap.set(r.assignee, cur)
+  }
+  const workloadHeatmap = Array.from(heatmapMap.entries()).map(([slug, days]) => ({ slug, days }))
+
+  // 6. Pipeline funnel
+  const funnelRes = await env.DB.prepare(
+    `SELECT stage, COUNT(*) as c FROM projects
+     WHERE deleted_at IS NULL AND status = 'active' AND stage IS NOT NULL
+     GROUP BY stage`
+  ).all<{ stage: string; c: number }>()
+  const STAGE_ORDER = ['Idea', 'Data Collection', 'Data Analysis', 'Writing', 'Review', 'Submitted', 'Published']
+  const funnelMap = new Map((funnelRes.results ?? []).map((r) => [r.stage, r.c]))
+  const pipelineFunnel = STAGE_ORDER.map((stage) => ({ stage, count: funnelMap.get(stage) ?? 0 }))
+
+  // 7. Velocity scatter + 8. stalled registry (single combined query)
+  const scatterRes = await env.DB.prepare(
+    `SELECT p.slug, p.title,
+       MAX(pu.created_at) as last_update,
+       (SELECT COUNT(*) FROM tasks t
+          WHERE t.project_id = p.id AND t.deleted_at IS NULL AND t.completed = 0) as open_tasks
+     FROM projects p
+     LEFT JOIN project_updates pu ON pu.project_id = p.id
+     WHERE p.deleted_at IS NULL AND p.status = 'active'
+     GROUP BY p.id, p.slug, p.title`
+  ).all<{ slug: string; title: string; last_update: string | null; open_tasks: number }>()
+
+  const now = Date.now()
+  const velocityScatter = (scatterRes.results ?? []).map((r) => {
+    const ms = r.last_update ? new Date(r.last_update).getTime() : 0
+    const daysSinceUpdate = ms === 0 ? 999 : Math.floor((now - ms) / 86400000)
+    const isOutlier = daysSinceUpdate > SCATTER_OUTLIER_DAYS || r.open_tasks > SCATTER_OUTLIER_TASKS
+    return { slug: r.slug, title: r.title, daysSinceUpdate, openTasks: r.open_tasks, isOutlier }
+  })
+
+  const stalledRegistry = velocityScatter
+    .filter((p) => p.daysSinceUpdate >= STALL_THRESHOLD_DAYS)
+    .map((p) => ({ slug: p.slug, title: p.title, daysIdle: p.daysSinceUpdate, openTasks: p.openTasks }))
+    .sort((a, b) => b.daysIdle - a.daysIdle)
+
+  const body: DashboardResponse = {
+    week,
+    metrics: {
+      stalledProjects: {
+        count: stalledNow?.c ?? 0,
+        deltaWoW: (stalledNow?.c ?? 0) - (stalledLast?.c ?? 0),
+      },
+      tasksPerPerson: { avg, total: totalOpen, distribution },
+      manuscriptsInRevision: {
+        count: msRevRes?.c ?? 0,
+        awaitingReplyOver7d: msAwaitingRes?.c ?? 0,
+      },
+      grantsInPipeline: {
+        count: grantsRes?.c ?? 0,
+        daysToNextDeadline,
+      },
+    },
+    workloadHeatmap,
+    pipelineFunnel,
+    velocityScatter,
+    stalledRegistry,
+  }
+
+  return new Response(JSON.stringify({ data: body }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=300, s-maxage=300',
+    },
+  })
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -131,6 +131,7 @@ const Ideas = lazy(() => import('./pages/portal/Ideas'))
 const SearchPage = lazy(() => import('./pages/portal/SearchPage'))
 const ActivityPage = lazy(() => import('./pages/portal/ActivityPage'))
 const AnalyticsPage = lazy(() => import('./pages/portal/AnalyticsPage'))
+const InsightsPage = lazy(() => import('./pages/portal/InsightsPage'))
 const SettingsPage = lazy(() => import('./pages/portal/SettingsPage'))
 const MeetingNotesPage = lazy(() => import('./pages/portal/MeetingNotesPage'))
 const DecisionsPage = lazy(() => import('./pages/portal/DecisionsPage'))
@@ -278,6 +279,7 @@ export default function App() {
                   <Route path="/portal/meeting-notes" element={<ErrorBoundary><MeetingNotesPage /></ErrorBoundary>} />
                   <Route path="/portal/activity" element={<ErrorBoundary><ActivityPage /></ErrorBoundary>} />
                   <Route path="/portal/analytics" element={<ErrorBoundary><AnalyticsPage /></ErrorBoundary>} />
+                  <Route path="/portal/insights" element={<ErrorBoundary><InsightsPage /></ErrorBoundary>} />
                   <Route path="/portal/pi/analytics" element={<ErrorBoundary><PageErrorBoundary pageName="PIAnalytics"><PIAnalytics /></PageErrorBoundary></ErrorBoundary>} />
                   <Route path="/portal/mentee-milestones" element={<ErrorBoundary><MenteeMilestones /></ErrorBoundary>} />
                   <Route path="/portal/pb" element={<ErrorBoundary><PBSector /></ErrorBoundary>} />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -98,6 +98,7 @@ const navGroups: NavGroup[] = [
       { to: '/team', label: 'Team', icon: UsersIcon },
       { to: PATHS.activity, label: 'Activity', icon: Activity },
       { to: PATHS.analytics, label: 'Analytics', icon: BarChart3 },
+      { to: PATHS.insights, label: 'Insights', icon: TrendingUp },
       { to: PATHS.settings, label: 'Settings', icon: Settings },
     ],
   },

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -46,6 +46,7 @@ export const PATHS = {
 
   activity: `${PORTAL_PREFIX}/activity`,
   analytics: `${PORTAL_PREFIX}/analytics`,
+  insights: `${PORTAL_PREFIX}/insights`,
   piAnalytics: `${PORTAL_PREFIX}/pi/analytics`,
   menteeMilestones: `${PORTAL_PREFIX}/mentee-milestones`,
   pb: `${PORTAL_PREFIX}/pb`,

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -1,0 +1,519 @@
+import { useMemo } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Link } from 'react-router-dom'
+import { TrendingUp, Activity, AlertTriangle, FlaskConical } from 'lucide-react'
+import PageHeader from '../../components/PageHeader'
+import EmptyState from '../../components/EmptyState'
+import { TextSkeleton } from '../../components/LoadingSkeleton'
+import { TableContainer } from '../../components/table'
+import { useToast } from '../../hooks/useToast'
+import { useAuth } from '../../hooks/useAuth'
+import { emailToSlug } from '../../lib/emailSlug'
+import { getPersonInfo } from '../../data/team'
+import { PATHS } from '../../constants/paths'
+import { usePageMeta } from '../../hooks/usePageMeta'
+
+interface DashboardData {
+  week: string
+  metrics: {
+    stalledProjects: { count: number; deltaWoW: number }
+    tasksPerPerson: { avg: number; total: number; distribution: { slug: string; count: number }[] }
+    manuscriptsInRevision: { count: number; awaitingReplyOver7d: number }
+    grantsInPipeline: { count: number; daysToNextDeadline: number | null }
+  }
+  workloadHeatmap: { slug: string; days: { mon: number; tue: number; wed: number; thu: number; fri: number } }[]
+  pipelineFunnel: { stage: string; count: number }[]
+  velocityScatter: { slug: string; title: string; daysSinceUpdate: number; openTasks: number; isOutlier: boolean }[]
+  stalledRegistry: { slug: string; title: string; daysIdle: number; openTasks: number }[]
+}
+
+const STAGE_FILL: Record<string, string> = {
+  'Idea': 'var(--stage-fill-idea)',
+  'Data Collection': 'var(--stage-fill-data-collection)',
+  'Data Analysis': 'var(--stage-fill-analysis)',
+  'Writing': 'var(--stage-fill-writing)',
+  'Review': 'var(--stage-fill-review)',
+  'Submitted': 'var(--stage-fill-submitted)',
+  'Published': 'var(--stage-fill-published)',
+}
+
+export default function InsightsPage() {
+  usePageMeta('Operational Insights | MN-CCORE', 'Where attention should go this week.')
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['insights-dashboard'],
+    queryFn: async () => {
+      const res = await fetch('/api/insights/dashboard')
+      if (res.status === 403) {
+        throw new Error('PI-only')
+      }
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const body = await res.json() as { data: DashboardData }
+      return body.data
+    },
+    staleTime: 5 * 60 * 1000,
+  })
+
+  if (isLoading) return <div className="content-container"><TextSkeleton lines={12} /></div>
+
+  if (isError) {
+    return (
+      <div className="content-container">
+        <PageHeader icon={<TrendingUp size={20} />} title="Operational Insights" />
+        <EmptyState
+          icon={<AlertTriangle size={40} />}
+          title="PI access required"
+          subtitle="Operational insights are visible to PIs only. If this is a mistake, check that your account has PI privileges."
+        />
+      </div>
+    )
+  }
+
+  if (!data) return null
+
+  return (
+    <div style={{ minHeight: '100vh' }}>
+      <div className="content-container" style={{ paddingBottom: '6rem' }}>
+        <PageHeader
+          icon={<TrendingUp size={20} />}
+          title="Operational Insights"
+          subtitle={`Hub aggregation · ${data.week}`}
+        />
+
+        {/* Metric hero row */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(200px, 1fr))',
+            gap: 'var(--sp-md)',
+            marginBottom: 'var(--sp-2xl)',
+          }}
+        >
+          <MetricHero
+            label="Stalled projects (14d+)"
+            value={data.metrics.stalledProjects.count}
+            delta={data.metrics.stalledProjects.deltaWoW}
+            accent={data.metrics.stalledProjects.count > 0 ? 'var(--maroon)' : 'var(--teal)'}
+          />
+          <MetricHero
+            label="Open tasks per person"
+            value={data.metrics.tasksPerPerson.avg}
+            sublabel={`${data.metrics.tasksPerPerson.total} total`}
+            accent="var(--teal)"
+          />
+          <MetricHero
+            label="Manuscripts in revision"
+            value={data.metrics.manuscriptsInRevision.count}
+            sublabel={
+              data.metrics.manuscriptsInRevision.awaitingReplyOver7d > 0
+                ? `${data.metrics.manuscriptsInRevision.awaitingReplyOver7d} awaiting reply >7d`
+                : undefined
+            }
+            sublabelColor={data.metrics.manuscriptsInRevision.awaitingReplyOver7d > 0 ? 'var(--maroon)' : undefined}
+            accent="var(--gold)"
+          />
+          <MetricHero
+            label="Grants in pipeline"
+            value={data.metrics.grantsInPipeline.count}
+            sublabel={
+              data.metrics.grantsInPipeline.daysToNextDeadline !== null
+                ? `Next deadline in ${data.metrics.grantsInPipeline.daysToNextDeadline}d`
+                : undefined
+            }
+            sublabelColor={
+              data.metrics.grantsInPipeline.daysToNextDeadline !== null && data.metrics.grantsInPipeline.daysToNextDeadline < 14
+                ? 'var(--gold)'
+                : undefined
+            }
+            accent="var(--gold)"
+          />
+        </div>
+
+        {/* Workload + funnel row */}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(auto-fit, minmax(360px, 1fr))',
+            gap: 'var(--sp-md)',
+            marginBottom: 'var(--sp-2xl)',
+          }}
+        >
+          <WorkloadHeatmap rows={data.workloadHeatmap} />
+          <PipelineFunnel rows={data.pipelineFunnel} />
+        </div>
+
+        {/* Velocity scatter */}
+        <VelocityScatter rows={data.velocityScatter} />
+
+        {/* Stalled registry */}
+        <div style={{ marginTop: 'var(--sp-2xl)' }}>
+          <SectionHeader icon={<AlertTriangle size={14} />} label="Critical stalled project registry" count={data.stalledRegistry.length} />
+          <StalledRegistry rows={data.stalledRegistry} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SectionHeader({ icon, label, count }: { icon: React.ReactNode; label: string; count?: number }) {
+  return (
+    <div className="flex items-center" style={{ gap: 8, marginBottom: 'var(--sp-sm)' }}>
+      <span style={{ color: 'var(--slate)', display: 'inline-flex' }}>{icon}</span>
+      <h2 style={{ fontSize: 14, fontWeight: 600, color: 'var(--ink)', margin: 0, letterSpacing: '0.02em' }}>{label}</h2>
+      {count !== undefined && count > 0 && (
+        <span style={{ fontSize: 11, color: 'var(--slate)', opacity: 0.85, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>
+          {count}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function MetricHero({
+  label, value, delta, sublabel, sublabelColor, accent,
+}: {
+  label: string; value: number; delta?: number; sublabel?: string; sublabelColor?: string; accent: string
+}) {
+  return (
+    <div
+      style={{
+        padding: 'var(--sp-lg)',
+        borderRadius: 'var(--radius-xl)',
+        background: 'var(--surface-1)',
+        border: '1px solid var(--border-subtle)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 6,
+      }}
+    >
+      <span style={{ fontSize: 11, fontWeight: 500, letterSpacing: '0.04em', color: 'var(--slate)', opacity: 0.85, textTransform: 'uppercase' }}>
+        {label}
+      </span>
+      <div className="flex items-baseline" style={{ gap: 8 }}>
+        <span style={{ fontSize: 32, fontWeight: 700, color: accent, fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>
+          {value}
+        </span>
+        {delta !== undefined && delta !== 0 && (
+          <span style={{ fontSize: 12, color: delta < 0 ? 'var(--green)' : 'var(--maroon)', fontWeight: 500 }}>
+            {delta > 0 ? '▲' : '▼'} {Math.abs(delta)} wk
+          </span>
+        )}
+      </div>
+      {sublabel && (
+        <span style={{ fontSize: 11, color: sublabelColor ?? 'var(--slate)', opacity: sublabelColor ? 1 : 0.85 }}>
+          {sublabel}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function WorkloadHeatmap({ rows }: { rows: DashboardData['workloadHeatmap'] }) {
+  const sorted = useMemo(() => [...rows].sort((a, b) => {
+    const ta = a.days.mon + a.days.tue + a.days.wed + a.days.thu + a.days.fri
+    const tb = b.days.mon + b.days.tue + b.days.wed + b.days.thu + b.days.fri
+    return tb - ta
+  }), [rows])
+
+  const cellColor = (n: number): string => {
+    if (n === 0) return 'rgba(255,255,255,0.03)'
+    if (n <= 3) return 'color-mix(in oklch, var(--stage-fill-data-collection) 30%, transparent)'
+    if (n <= 8) return 'color-mix(in oklch, var(--stage-fill-data-collection) 60%, transparent)'
+    return 'var(--stage-fill-data-collection)'
+  }
+  const days: ('mon'|'tue'|'wed'|'thu'|'fri')[] = ['mon', 'tue', 'wed', 'thu', 'fri']
+  const labels = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
+
+  return (
+    <div style={{ padding: 'var(--sp-lg)', borderRadius: 'var(--radius-xl)', background: 'var(--surface-1)', border: '1px solid var(--border-subtle)' }}>
+      <SectionHeader icon={<Activity size={14} />} label="Workload heatmap" count={sorted.length} />
+      {sorted.length === 0 ? (
+        <p style={{ fontSize: 12, color: 'var(--slate)', opacity: 0.85, margin: 0 }}>
+          No tasks scheduled for the current week.
+        </p>
+      ) : (
+        <>
+          <div role="grid" aria-label="Tasks due this week per member per weekday" style={{ display: 'grid', gridTemplateColumns: '120px repeat(5, 1fr)', gap: 4, alignItems: 'center' }}>
+            <span aria-hidden="true" />
+            {labels.map((l) => (
+              <span key={l} role="columnheader" style={{ fontSize: 10, color: 'var(--slate)', opacity: 0.7, textAlign: 'center', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
+                {l}
+              </span>
+            ))}
+            {sorted.map((row) => {
+              const person = getPersonInfo(row.slug)
+              return (
+                <>
+                  <span key={`${row.slug}-name`} role="rowheader" style={{ fontSize: 12, color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', paddingRight: 8 }}>
+                    {person.name}
+                  </span>
+                  {days.map((d) => (
+                    <div
+                      key={`${row.slug}-${d}`}
+                      role="gridcell"
+                      aria-label={`${person.name}: ${d}: ${row.days[d]} open tasks`}
+                      style={{
+                        height: 22,
+                        borderRadius: 'var(--radius-sm)',
+                        background: cellColor(row.days[d]),
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: 10,
+                        color: row.days[d] >= 4 ? '#fff' : 'var(--slate)',
+                        fontWeight: 500,
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    >
+                      {row.days[d] > 0 ? row.days[d] : ''}
+                    </div>
+                  ))}
+                </>
+              )
+            })}
+          </div>
+          <div className="flex items-center" style={{ gap: 12, marginTop: 12, fontSize: 10, color: 'var(--slate)', opacity: 0.85 }}>
+            <span>Legend:</span>
+            {[
+              ['low (1-3)', 'color-mix(in oklch, var(--stage-fill-data-collection) 30%, transparent)'],
+              ['med (4-8)', 'color-mix(in oklch, var(--stage-fill-data-collection) 60%, transparent)'],
+              ['high (9+)', 'var(--stage-fill-data-collection)'],
+            ].map(([label, bg]) => (
+              <span key={label} className="flex items-center" style={{ gap: 4 }}>
+                <span style={{ width: 10, height: 10, borderRadius: 'var(--radius-sm)', background: bg }} />
+                {label}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function PipelineFunnel({ rows }: { rows: DashboardData['pipelineFunnel'] }) {
+  const max = Math.max(1, ...rows.map((r) => r.count))
+  return (
+    <div style={{ padding: 'var(--sp-lg)', borderRadius: 'var(--radius-xl)', background: 'var(--surface-1)', border: '1px solid var(--border-subtle)' }}>
+      <SectionHeader icon={<FlaskConical size={14} />} label="Pipeline funnel" />
+      <div className="flex flex-col" style={{ gap: 6 }}>
+        {rows.map((r) => {
+          const pct = (r.count / max) * 100
+          return (
+            <div
+              key={r.stage}
+              role="img"
+              aria-label={`${r.stage}: ${r.count} projects`}
+              className="flex items-center"
+              style={{ gap: 8 }}
+            >
+              <span style={{ flex: '0 0 110px', fontSize: 11, color: 'var(--slate)', textAlign: 'right', whiteSpace: 'nowrap' }}>
+                {r.stage}
+              </span>
+              <div style={{ flex: 1, height: 22, position: 'relative', background: 'rgba(255,255,255,0.03)', borderRadius: 'var(--radius-sm)' }}>
+                <div
+                  style={{
+                    width: `${pct}%`,
+                    height: '100%',
+                    background: STAGE_FILL[r.stage] ?? 'var(--stage-fill-idea)',
+                    borderRadius: 'var(--radius-sm)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'flex-end',
+                    paddingRight: 8,
+                    color: '#fff',
+                    fontSize: 11,
+                    fontWeight: 600,
+                    fontVariantNumeric: 'tabular-nums',
+                  }}
+                >
+                  {r.count > 0 ? r.count : ''}
+                </div>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+function VelocityScatter({ rows }: { rows: DashboardData['velocityScatter'] }) {
+  const maxX = Math.max(60, ...rows.map((r) => r.daysSinceUpdate))
+  const maxY = Math.max(10, ...rows.map((r) => r.openTasks))
+  const w = 700
+  const h = 240
+  const padL = 36
+  const padB = 28
+
+  return (
+    <div style={{ padding: 'var(--sp-lg)', borderRadius: 'var(--radius-xl)', background: 'var(--surface-1)', border: '1px solid var(--border-subtle)' }}>
+      <SectionHeader icon={<TrendingUp size={14} />} label="Project velocity outliers" count={rows.filter(r => r.isOutlier).length} />
+      <p style={{ fontSize: 11, color: 'var(--slate)', opacity: 0.85, margin: '0 0 12px' }}>
+        x = days since last update · y = open task count · maroon = outlier (&gt;30d OR &gt;10 tasks)
+      </p>
+      <div style={{ overflow: 'auto' }}>
+        <svg width={w} height={h} role="img" aria-label="Project velocity scatter chart">
+          {/* axes */}
+          <line x1={padL} y1={h - padB} x2={w - 8} y2={h - padB} stroke="var(--border-subtle)" />
+          <line x1={padL} y1={8} x2={padL} y2={h - padB} stroke="var(--border-subtle)" />
+          {/* points */}
+          {rows.map((r) => {
+            const cx = padL + (r.daysSinceUpdate / maxX) * (w - padL - 16)
+            const cy = (h - padB) - (r.openTasks / maxY) * (h - padB - 16)
+            return (
+              <circle
+                key={r.slug}
+                cx={cx}
+                cy={cy}
+                r={r.isOutlier ? 5 : 3}
+                fill={r.isOutlier ? 'var(--maroon)' : 'var(--teal)'}
+                opacity={r.isOutlier ? 0.9 : 0.7}
+              >
+                <title>{`${r.title} — ${r.daysSinceUpdate}d, ${r.openTasks} open`}</title>
+              </circle>
+            )
+          })}
+        </svg>
+      </div>
+      <details style={{ marginTop: 8 }}>
+        <summary style={{ fontSize: 11, color: 'var(--slate)', cursor: 'pointer' }}>Show as table</summary>
+        <table style={{ marginTop: 8, fontSize: 12, width: '100%', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ textAlign: 'left', color: 'var(--slate)' }}>
+              <th style={{ padding: '4px 8px', fontWeight: 500 }}>Project</th>
+              <th style={{ padding: '4px 8px', fontWeight: 500 }}>Days idle</th>
+              <th style={{ padding: '4px 8px', fontWeight: 500 }}>Open tasks</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr key={r.slug} style={{ color: r.isOutlier ? 'var(--maroon)' : 'var(--ink)' }}>
+                <td style={{ padding: '4px 8px' }}>{r.title}</td>
+                <td style={{ padding: '4px 8px', fontVariantNumeric: 'tabular-nums' }}>{r.daysSinceUpdate}</td>
+                <td style={{ padding: '4px 8px', fontVariantNumeric: 'tabular-nums' }}>{r.openTasks}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </details>
+    </div>
+  )
+}
+
+function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
+  const queryClient = useQueryClient()
+  const { showSuccess } = useToast()
+  const { user } = useAuth()
+  const followUp = useMutation({
+    mutationFn: async (project: { slug: string; title: string }) => {
+      const due = new Date()
+      due.setDate(due.getDate() + 3)
+      const dueStr = due.toISOString().slice(0, 10)
+      const res = await fetch('/api/tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: `Follow up on stalled project: ${project.title}`,
+          assignee: emailToSlug(user?.email) || 'nick-ingraham',
+          project_id: project.slug,
+          priority: 'high',
+          due_date: dueStr,
+          status: 'todo',
+        }),
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['tasks'] })
+      showSuccess('Follow-up task created')
+    },
+  })
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        icon={<TrendingUp size={32} />}
+        title="No stalled projects"
+        subtitle="Every active project has had a project_update within the last 14 days."
+      />
+    )
+  }
+
+  return (
+    <TableContainer>
+      <div className="hidden sm:grid" style={{ gridTemplateColumns: 'minmax(220px, 3fr) 100px 100px 160px', padding: 'var(--sp-sm) var(--sp-xl)', borderBottom: '1px solid var(--border-subtle)' }}>
+        {['Project', 'Days idle', 'Open tasks', 'Action'].map((label) => (
+          <span key={label} style={{ fontSize: 10, textTransform: 'uppercase', color: 'var(--slate)', opacity: 0.55, letterSpacing: '0.06em', fontWeight: 500 }}>
+            {label}
+          </span>
+        ))}
+      </div>
+      {rows.map((r) => (
+        <div
+          key={r.slug}
+          className="hidden sm:grid"
+          style={{
+            gridTemplateColumns: 'minmax(220px, 3fr) 100px 100px 160px',
+            padding: 'var(--sp-md) var(--sp-xl)',
+            borderBottom: '1px solid var(--border-subtle)',
+            alignItems: 'center',
+            color: 'var(--ink)',
+            fontSize: 13,
+          }}
+        >
+          <Link to={PATHS.project(r.slug)} style={{ color: 'var(--ink)', textDecoration: 'none', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {r.title}
+          </Link>
+          <span style={{ color: 'var(--maroon)', fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>
+            {r.daysIdle}d
+          </span>
+          <span style={{ color: 'var(--slate)', fontVariantNumeric: 'tabular-nums' }}>
+            {r.openTasks}
+          </span>
+          <button
+            type="button"
+            onClick={() => followUp.mutate({ slug: r.slug, title: r.title })}
+            disabled={followUp.isPending}
+            style={{
+              padding: '4px 10px',
+              fontSize: 11,
+              fontWeight: 500,
+              color: 'var(--teal)',
+              background: 'transparent',
+              border: '1px solid var(--teal)',
+              borderRadius: 'var(--radius-md)',
+              cursor: 'pointer',
+              width: 'fit-content',
+            }}
+          >
+            + Set follow-up
+          </button>
+        </div>
+      ))}
+      {/* Mobile fallback — single-column stack */}
+      {rows.map((r) => (
+        <div
+          key={`m-${r.slug}`}
+          className="sm:hidden"
+          style={{ padding: 'var(--sp-md)', borderBottom: '1px solid var(--border-subtle)' }}
+        >
+          <Link to={PATHS.project(r.slug)} style={{ color: 'var(--ink)', textDecoration: 'none', fontSize: 13, fontWeight: 500 }}>
+            {r.title}
+          </Link>
+          <div className="flex items-center" style={{ gap: 12, marginTop: 4, fontSize: 11 }}>
+            <span style={{ color: 'var(--maroon)', fontWeight: 600 }}>{r.daysIdle}d idle</span>
+            <span style={{ color: 'var(--slate)' }}>{r.openTasks} tasks</span>
+            <button
+              onClick={() => followUp.mutate({ slug: r.slug, title: r.title })}
+              style={{ marginLeft: 'auto', padding: '4px 10px', fontSize: 11, color: 'var(--teal)', background: 'transparent', border: '1px solid var(--teal)', borderRadius: 'var(--radius-md)' }}
+            >
+              + Follow-up
+            </button>
+          </div>
+        </div>
+      ))}
+    </TableContainer>
+  )
+}

--- a/tests/helpers/paths.ts
+++ b/tests/helpers/paths.ts
@@ -34,6 +34,7 @@ export const P = {
   meetingNotes: '/portal/meeting-notes',
   activity: '/portal/activity',
   analytics: '/portal/analytics',
+  insights: '/portal/insights',
   piAnalytics: '/portal/pi/analytics',
   menteeMilestones: '/portal/mentee-milestones',
   pb: '/portal/pb',


### PR DESCRIPTION
Closes #37 (EPIC).

Plan-ready brief at `docs/design-briefs/2026-04-26-insights-page.md` was the source of truth.

**Endpoint** `GET /api/insights/dashboard` (PI-gated via `isPiRequest()`, 5-min edge cache):
- `metrics.stalledProjects` — count + WoW delta (14d threshold)
- `metrics.tasksPerPerson` — avg / total / per-member distribution
- `metrics.manuscriptsInRevision` — count + awaitingReply >7d
- `metrics.grantsInPipeline` — count + days to next deadline
- `workloadHeatmap` — 19 members × 5 weekdays
- `pipelineFunnel` — 7 canonical stages
- `velocityScatter` — per-project (days idle × open tasks); outlier flag at >30d or >10 tasks
- `stalledRegistry` — sorted projects ≥14d idle

All 5 SQL queries on existing tables — **no new tables, no new migrations**.

**Page** `/portal/insights` (`src/pages/portal/InsightsPage.tsx`):
- 4 metric hero cards (auto-fit grid)
- Workload heatmap with 3-bin teal scale + legend, sorted by total weekly load
- Pipeline funnel using `--stage-fill-*` tokens (Rule 41) — white text passes AA on all 7 fills
- Velocity scatter (SVG); maroon outliers, `<details>` table fallback for a11y
- Stalled-projects registry with inline `+ Set follow-up` CTA

**Follow-up CTA** creates a high-priority task assigned to the current PI, due +3 days, linked to the stalled project. Reuses `POST /api/tasks` — no new mutation endpoint needed.

**Wired:** `PATHS.insights`, `App.tsx` route, Sidebar entry (Research group), `tests/helpers/paths.ts`.

Source: Stitch consultant batch 2026-04-26 mockup #05 (r1). Build clean.