### PR TITLE
feat(calendar): personal iCal feeds for Today timeline

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -22,6 +22,7 @@ import { handleSearch } from './routes/search';
 import { handleGetSettings, handleUpdateSettings, handleGetWorkflowTemplates, handleCreateWorkflowTemplate } from './routes/settings';
 import { handleGetReactions, handleToggleReaction } from './routes/reactions';
 import { handleCalendarEvents } from './routes/calendar';
+import { handleListFeeds, handleAddFeed, handleDeleteFeed, handleListEvents } from './routes/calendar-feeds';
 import { handleActivity, handleActivityHeatmap } from './routes/activity';
 import { handleGetSubtasks, handleCreateSubtask, handleToggleSubtask, handleDeleteSubtask, handleReorderSubtasks } from './routes/subtasks';
 import { handleTeamPulse } from './routes/team-pulse';
@@ -476,6 +477,14 @@ app.get('/api/search', (c) => handleSearch(U(c), E(c)));
 app.get('/api/settings', (c) => handleGetSettings(E(c)));
 app.get('/api/workflow-templates', (c) => handleGetWorkflowTemplates(E(c)));
 app.get('/api/calendar/events', (c) => handleCalendarEvents(U(c), E(c)));
+
+// Personal iCal calendar feeds (issue #45). Per-user, secret URL stays in D1.
+// These use `authedUser` (real JWT identity) not `user` (anonymous fallback)
+// because the feed_url is a secret — no anonymous access path.
+app.get('/api/integrations/calendar/feeds', (c) => handleListFeeds(E(c), c.get('authedUser')));
+app.post('/api/integrations/calendar/feeds', (c) => handleAddFeed(R(c), E(c), c.get('authedUser')));
+app.delete('/api/integrations/calendar/feeds/:id', (c) => handleDeleteFeed(E(c), c.get('authedUser'), c.req.param('id')));
+app.get('/api/integrations/calendar/events', (c) => handleListEvents(U(c), E(c), c.get('authedUser')));
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Files (presigned URLs etc.)

--- a/api/lib/ics-parser.test.ts
+++ b/api/lib/ics-parser.test.ts
@@ -1,0 +1,353 @@
+import { describe, it, expect } from 'vitest'
+import { parseIcs } from './ics-parser'
+
+// Fixed window for deterministic RRULE expansion. All test events anchor
+// in 2026-04 so this window contains them but is generous on the right
+// to confirm RRULE expansion respects bounds.
+const WIN = {
+  windowStart: '2026-04-01T00:00:00.000Z',
+  windowEnd: '2026-06-30T23:59:59.000Z',
+}
+
+function ical(...parts: string[]): string {
+  return ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//test//EN', ...parts, 'END:VCALENDAR'].join('\r\n')
+}
+
+function vevent(props: Record<string, string | string[]>): string {
+  const out: string[] = ['BEGIN:VEVENT']
+  for (const [k, v] of Object.entries(props)) {
+    if (Array.isArray(v)) {
+      for (const item of v) out.push(`${k}:${item}`)
+    } else {
+      out.push(`${k}:${v}`)
+    }
+  }
+  out.push('END:VEVENT')
+  return out.join('\r\n')
+}
+
+describe('parseIcs — basic', () => {
+  it('parses a simple UTC event', () => {
+    const ics = ical(vevent({
+      UID: 'evt-1',
+      SUMMARY: 'Lab meeting',
+      DTSTART: '20260415T140000Z',
+      DTEND: '20260415T150000Z',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(1)
+    expect(out[0].uid).toBe('evt-1')
+    expect(out[0].summary).toBe('Lab meeting')
+    expect(out[0].startAt).toBe('2026-04-15T14:00:00.000Z')
+    expect(out[0].endAt).toBe('2026-04-15T15:00:00.000Z')
+    expect(out[0].isAllDay).toBe(false)
+  })
+
+  it('parses an all-day event', () => {
+    const ics = ical(vevent({
+      UID: 'allday-1',
+      SUMMARY: 'Conference day',
+      'DTSTART;VALUE=DATE': '20260420',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(1)
+    expect(out[0].isAllDay).toBe(true)
+    expect(out[0].startAt).toBe('2026-04-20T00:00:00.000Z')
+  })
+
+  it('drops cancelled events', () => {
+    const ics = ical(
+      vevent({ UID: 'a', SUMMARY: 'Active', DTSTART: '20260415T140000Z' }),
+      vevent({ UID: 'b', SUMMARY: 'Cancelled', DTSTART: '20260416T140000Z', STATUS: 'CANCELLED' }),
+    )
+    const out = parseIcs(ics, WIN)
+    expect(out.map((e) => e.uid)).toEqual(['a'])
+  })
+
+  it('drops events the owner declined', () => {
+    const ics = ical(
+      vevent({
+        UID: 'declined-1',
+        SUMMARY: 'Recruiter pitch',
+        DTSTART: '20260415T140000Z',
+        ATTENDEE: ['CN=Nick;PARTSTAT=DECLINED:mailto:ingra107@umn.edu'],
+      }),
+      vevent({
+        UID: 'accepted-1',
+        SUMMARY: 'Lab',
+        DTSTART: '20260416T140000Z',
+        ATTENDEE: ['CN=Nick;PARTSTAT=ACCEPTED:mailto:ingra107@umn.edu'],
+      }),
+    )
+    const out = parseIcs(ics, { ...WIN, ownerEmail: 'ingra107@umn.edu' })
+    expect(out.map((e) => e.uid)).toEqual(['accepted-1'])
+  })
+
+  it('keeps declined events when no ownerEmail provided', () => {
+    const ics = ical(vevent({
+      UID: 'declined-1',
+      SUMMARY: 'Recruiter pitch',
+      DTSTART: '20260415T140000Z',
+      ATTENDEE: ['CN=Nick;PARTSTAT=DECLINED:mailto:ingra107@umn.edu'],
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(1)
+  })
+
+  it('dedups by (summary, startAt)', () => {
+    const ics = ical(
+      vevent({ UID: 'dup-1', SUMMARY: 'Same', DTSTART: '20260415T140000Z' }),
+      vevent({ UID: 'dup-2', SUMMARY: 'Same', DTSTART: '20260415T140000Z' }),
+    )
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(1)
+  })
+})
+
+describe('parseIcs — line unfolding', () => {
+  it('joins continuation lines per RFC 5545', () => {
+    // RFC 5545 §3.1: CRLF + leading space/tab marks a continuation. The
+    // marker is stripped; the remaining content is concatenated with no
+    // inserted space. To preserve a space at the wrap point, the original
+    // line must include the space before the wrap.
+    const ics = ical(['BEGIN:VEVENT',
+      'UID:fold-1',
+      'SUMMARY:This is a really long meeting ',
+      ' name continued',
+      'DTSTART:20260415T140000Z',
+      'END:VEVENT'].join('\r\n'))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].summary).toBe('This is a really long meeting name continued')
+  })
+})
+
+describe('parseIcs — TZID resolution', () => {
+  it('converts America/Chicago wall-clock to correct UTC (CDT)', () => {
+    // CDT (April) is UTC-5. 14:00 local = 19:00 UTC.
+    const ics = ical(vevent({
+      UID: 'tz-1',
+      SUMMARY: 'TZ test',
+      'DTSTART;TZID=America/Chicago': '20260415T140000',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].startAt).toBe('2026-04-15T19:00:00.000Z')
+  })
+
+  it('converts America/Chicago wall-clock to correct UTC (CST)', () => {
+    // CST (January) is UTC-6. 14:00 local = 20:00 UTC.
+    // Window expanded to include January.
+    const ics = ical(vevent({
+      UID: 'tz-2',
+      SUMMARY: 'TZ winter',
+      'DTSTART;TZID=America/Chicago': '20260115T140000',
+    }))
+    const out = parseIcs(ics, { windowStart: '2026-01-01T00:00:00.000Z', windowEnd: '2026-12-31T23:59:59.000Z' })
+    expect(out[0].startAt).toBe('2026-01-15T20:00:00.000Z')
+  })
+
+  it('falls back to UTC for unknown TZID', () => {
+    const ics = ical(vevent({
+      UID: 'tz-bad',
+      SUMMARY: 'Unknown tz',
+      'DTSTART;TZID=Mars/Olympus': '20260415T140000',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].startAt).toBe('2026-04-15T14:00:00.000Z')
+  })
+})
+
+describe('parseIcs — RRULE expansion', () => {
+  it('expands FREQ=WEEKLY with BYDAY', () => {
+    // Tuesday Apr 7 2026; expand 4 weeks of Tuesday + Thursday.
+    const ics = ical(vevent({
+      UID: 'rec-1',
+      SUMMARY: 'Office hours',
+      DTSTART: '20260407T140000Z',
+      DTEND: '20260407T150000Z',
+      RRULE: 'FREQ=WEEKLY;BYDAY=TU,TH;COUNT=8',
+    }))
+    const out = parseIcs(ics, WIN)
+    // 8 occurrences total
+    expect(out).toHaveLength(8)
+    // First 4 starts (chronological, dedup'd by parseIcs sort)
+    const dates = out.map((e) => e.startAt.slice(0, 10))
+    expect(dates.slice(0, 4)).toEqual(['2026-04-07', '2026-04-09', '2026-04-14', '2026-04-16'])
+  })
+
+  it('expands FREQ=WEEKLY;INTERVAL=2 (biweekly)', () => {
+    const ics = ical(vevent({
+      UID: 'biw-1',
+      SUMMARY: '1:1',
+      DTSTART: '20260406T160000Z',  // Monday
+      RRULE: 'FREQ=WEEKLY;INTERVAL=2;BYDAY=MO;COUNT=4',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(4)
+    expect(out.map((e) => e.startAt.slice(0, 10))).toEqual(['2026-04-06', '2026-04-20', '2026-05-04', '2026-05-18'])
+  })
+
+  it('expands FREQ=MONTHLY with BYDAY=1MO (first Monday)', () => {
+    const ics = ical(vevent({
+      UID: 'mon-1',
+      SUMMARY: 'Faculty meeting',
+      DTSTART: '20260406T180000Z',  // Apr 6 = first Monday
+      RRULE: 'FREQ=MONTHLY;BYDAY=1MO;COUNT=3',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(3)
+    expect(out.map((e) => e.startAt.slice(0, 10))).toEqual(['2026-04-06', '2026-05-04', '2026-06-01'])
+  })
+
+  it('honors UNTIL', () => {
+    const ics = ical(vevent({
+      UID: 'until-1',
+      SUMMARY: 'Daily standup',
+      DTSTART: '20260413T140000Z',
+      RRULE: 'FREQ=DAILY;UNTIL=20260417T140000Z',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out.map((e) => e.startAt.slice(0, 10))).toEqual([
+      '2026-04-13', '2026-04-14', '2026-04-15', '2026-04-16', '2026-04-17',
+    ])
+  })
+
+  it('skips EXDATE-excluded instances', () => {
+    const ics = ical(vevent({
+      UID: 'exd-1',
+      SUMMARY: 'Weekly',
+      DTSTART: '20260406T140000Z',
+      RRULE: 'FREQ=WEEKLY;BYDAY=MO;COUNT=4',
+      EXDATE: '20260420T140000Z',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(3)
+    expect(out.map((e) => e.startAt.slice(0, 10))).not.toContain('2026-04-20')
+  })
+
+  it('honors RECURRENCE-ID overrides', () => {
+    const ics = ical(
+      vevent({
+        UID: 'over-1',
+        SUMMARY: 'Standup',
+        DTSTART: '20260406T140000Z',
+        RRULE: 'FREQ=WEEKLY;BYDAY=MO;COUNT=3',
+      }),
+      vevent({
+        UID: 'over-1',
+        SUMMARY: 'Standup (rescheduled)',
+        DTSTART: '20260413T160000Z',
+        'RECURRENCE-ID': '20260413T140000Z',
+      }),
+    )
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(3)
+    const moved = out.find((e) => e.summary === 'Standup (rescheduled)')
+    expect(moved).toBeDefined()
+    expect(moved!.startAt).toBe('2026-04-13T16:00:00.000Z')
+    // Original 14:00 instance should be gone
+    expect(out.filter((e) => e.startAt === '2026-04-13T14:00:00.000Z')).toHaveLength(0)
+  })
+
+  it('cancelled RECURRENCE-ID drops just that instance', () => {
+    const ics = ical(
+      vevent({
+        UID: 'can-1',
+        SUMMARY: 'Standup',
+        DTSTART: '20260406T140000Z',
+        RRULE: 'FREQ=WEEKLY;BYDAY=MO;COUNT=3',
+      }),
+      vevent({
+        UID: 'can-1',
+        SUMMARY: 'Standup',
+        DTSTART: '20260413T140000Z',
+        'RECURRENCE-ID': '20260413T140000Z',
+        STATUS: 'CANCELLED',
+      }),
+    )
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(2)
+    expect(out.map((e) => e.startAt.slice(0, 10))).toEqual(['2026-04-06', '2026-04-20'])
+  })
+})
+
+describe('parseIcs — meeting URL extraction', () => {
+  it('extracts Zoom URL from DESCRIPTION when LOCATION is empty', () => {
+    const ics = ical(vevent({
+      UID: 'zoom-1',
+      SUMMARY: 'Lab',
+      DTSTART: '20260415T140000Z',
+      DESCRIPTION: 'Join here: https://umn.zoom.us/j/1234567890?pwd=abc Some other text',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].location).toBe('https://umn.zoom.us/j/1234567890?pwd=abc')
+  })
+
+  it('extracts Google Meet URL', () => {
+    const ics = ical(vevent({
+      UID: 'meet-1',
+      SUMMARY: 'Lab',
+      DTSTART: '20260415T140000Z',
+      DESCRIPTION: 'https://meet.google.com/abc-defg-hij',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].location).toBe('https://meet.google.com/abc-defg-hij')
+  })
+
+  it('strips Google redirect tracking from URLs', () => {
+    const ics = ical(vevent({
+      UID: 'gtrack-1',
+      SUMMARY: 'Lab',
+      DTSTART: '20260415T140000Z',
+      LOCATION: 'https://umn.zoom.us/j/1234567890&sa=D&source=calendar',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].location).toBe('https://umn.zoom.us/j/1234567890')
+  })
+
+  it('keeps non-URL location as-is', () => {
+    const ics = ical(vevent({
+      UID: 'room-1',
+      SUMMARY: 'Lab',
+      DTSTART: '20260415T140000Z',
+      LOCATION: 'PWB 14-152',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out[0].location).toBe('PWB 14-152')
+  })
+})
+
+describe('parseIcs — window bounds', () => {
+  it('drops events before windowStart', () => {
+    const ics = ical(vevent({
+      UID: 'old',
+      SUMMARY: 'Old',
+      DTSTART: '20251215T140000Z',  // way before window
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(0)
+  })
+
+  it('drops events after windowEnd', () => {
+    const ics = ical(vevent({
+      UID: 'far',
+      SUMMARY: 'Far future',
+      DTSTART: '20271215T140000Z',
+    }))
+    const out = parseIcs(ics, WIN)
+    expect(out).toHaveLength(0)
+  })
+
+  it('caps RRULE expansion at hard maximum', () => {
+    // FREQ=DAILY with no UNTIL/COUNT — would run for years without the cap.
+    const ics = ical(vevent({
+      UID: 'forever',
+      SUMMARY: 'Eternal',
+      DTSTART: '20260401T140000Z',
+      RRULE: 'FREQ=DAILY',
+    }))
+    const out = parseIcs(ics, WIN)
+    // Window is Apr 1 .. Jun 30 = 91 days max; should be 91 instances.
+    expect(out.length).toBeLessThanOrEqual(91)
+    expect(out.length).toBeGreaterThan(80)
+  })
+})

--- a/api/lib/ics-parser.ts
+++ b/api/lib/ics-parser.ts
@@ -1,56 +1,92 @@
-// Minimal iCalendar (RFC 5545) VEVENT parser. Pure JS, no deps — runs in
-// Cloudflare Workers without Node polyfills. Handles the subset Google /
-// Outlook / iCloud actually emit:
-//   - VEVENT blocks (ignores VTODO, VJOURNAL, VTIMEZONE, etc.)
-//   - DTSTART / DTEND with optional TZID= or VALUE=DATE (all-day)
-//   - SUMMARY, UID, LOCATION, DESCRIPTION
-//   - Line unfolding (RFC 5545 §3.1: CRLF + space/tab continues prior line)
-//   - Basic backslash escapes (\\n, \\,, \\;, \\\\)
-//   - RRULE expansion: NOT supported. Recurring events surface only their
-//     master DTSTART; recurrences within the polling window are missed.
-//     This is acceptable for a 15-min cache feeding a "today timeline" —
-//     fix when someone reports a missing weekly meeting. (TODO #45-followup)
+// iCalendar (RFC 5545) parser. Pure JS, no deps — runs in Cloudflare
+// Workers without Node polyfills.
 //
-// TZID handling: Workers have no IANA timezone DB. We treat TZID values as
-// hints and parse the local time as wall-clock; output is the wall-clock
-// converted naively to UTC. Practical impact: all-day events render
-// correctly; timed events drift by the user's UTC offset only when the
-// server-side conversion matters (e.g., today-vs-tomorrow at midnight
-// boundaries). Acceptable for v1; document limitation.
+// This parser is the Workers-side port of Peripheral Brain's
+// `scripts/fetch_calendar.py`, which has been refined for ~6 months
+// against Nick's UMN Google Calendar feed. The refinements are not
+// optional; they are what make the data usable on TODAY.md.
+//
+// Capabilities:
+//   - VEVENT blocks (other components ignored)
+//   - DTSTART / DTEND with TZID= (resolved via Intl.DateTimeFormat) or
+//     VALUE=DATE (all-day) or floating UTC (Z suffix)
+//   - SUMMARY, UID, LOCATION, DESCRIPTION
+//   - Line unfolding (RFC 5545 §3.1)
+//   - Backslash escapes (\\n, \\,, \\;, \\\\)
+//   - RRULE expansion: FREQ DAILY|WEEKLY|MONTHLY|YEARLY with INTERVAL,
+//     BYDAY, BYMONTHDAY, BYMONTH, COUNT, UNTIL — bounded by caller-provided
+//     window (today-7..today+90 by default).
+//   - EXDATE exclusions (multi-occurrence accumulated)
+//   - RECURRENCE-ID overrides
+//   - STATUS=CANCELLED filtering
+//   - PARTSTAT=DECLINED filtering (per-user email)
+//   - Meeting URL extraction from DESCRIPTION (Zoom / Teams / Google Meet)
+//   - Google redirect URL cleanup (`&sa=D`, `&amp;`, percent-encoding)
+//   - Dedup by (summary, startAt)
+//   - UNTIL with early UTC time → "ended previous day" heuristic
 
 export interface IcsEvent {
   uid: string
   summary: string
   description: string | null
   location: string | null
-  startAt: string  // ISO-8601, UTC if known, else wall-clock + 'Z'
+  startAt: string  // ISO-8601 UTC
   endAt: string | null
   isAllDay: boolean
 }
 
-export function parseIcs(raw: string): IcsEvent[] {
+export interface ParseOptions {
+  /** ISO date — events ending before this are dropped. Default: 7 days ago. */
+  windowStart?: string
+  /** ISO date — events starting after this are dropped. Default: 90 days ahead. */
+  windowEnd?: string
+  /** Owner's email — events with PARTSTAT=DECLINED for this attendee are dropped.
+   *  Without this, declined events surface and clutter Today's timeline. */
+  ownerEmail?: string
+}
+
+export function parseIcs(raw: string, opts: ParseOptions = {}): IcsEvent[] {
+  const windowStart = opts.windowStart ?? new Date(Date.now() - 7 * 86400000).toISOString()
+  const windowEnd = opts.windowEnd ?? new Date(Date.now() + 90 * 86400000).toISOString()
+  const ownerEmail = opts.ownerEmail?.toLowerCase()
+
   const unfolded = unfoldLines(raw)
-  const events: IcsEvent[] = []
-  let current: Partial<IcsEvent> | null = null
+  const masters: ParsedVEvent[] = []
+  // RECURRENCE-ID overrides: keyed by `${uid}|${recurrence-id-iso}`.
+  const overrides = new Map<string, ParsedVEvent>()
+
+  let current: Partial<ParsedVEvent> | null = null
   let inEvent = false
 
   for (const line of unfolded) {
     if (line === 'BEGIN:VEVENT') {
       inEvent = true
-      current = {}
+      current = { exdates: [], attendees: [] }
       continue
     }
     if (line === 'END:VEVENT') {
       if (current && current.uid && current.startAt) {
-        events.push({
-          uid: current.uid,
-          summary: current.summary ?? '(no title)',
-          description: current.description ?? null,
-          location: current.location ?? null,
-          startAt: current.startAt,
-          endAt: current.endAt ?? null,
-          isAllDay: current.isAllDay ?? false,
-        })
+        const ev = current as ParsedVEvent
+        // Skip events the owner declined (applies to both masters and overrides).
+        const declined = ownerEmail && (ev.attendees ?? []).some((a) =>
+          a.toLowerCase().includes(ownerEmail) && /PARTSTAT=DECLINED/i.test(a)
+        )
+        if (declined) {
+          current = null; inEvent = false; continue
+        }
+        // Cancelled events: if it's a RECURRENCE-ID override, keep the
+        // record so expansion can drop just that instance. Otherwise (a
+        // master cancellation) skip entirely.
+        if (ev.status === 'CANCELLED' && !ev.recurrenceId) {
+          current = null; inEvent = false; continue
+        }
+        // Enrich location from DESCRIPTION if it doesn't already carry a URL.
+        ev.location = enrichLocation(ev.location ?? null, ev.description ?? null)
+        if (ev.recurrenceId) {
+          overrides.set(`${ev.uid}|${ev.recurrenceId}`, ev)
+        } else {
+          masters.push(ev)
+        }
       }
       current = null
       inEvent = false
@@ -62,28 +98,31 @@ export function parseIcs(raw: string): IcsEvent[] {
     if (colon === -1) continue
     const rawKey = line.slice(0, colon)
     const value = line.slice(colon + 1)
-    // Property name may carry params: DTSTART;TZID=America/Chicago:...
     const semi = rawKey.indexOf(';')
     const name = (semi === -1 ? rawKey : rawKey.slice(0, semi)).toUpperCase()
     const params = semi === -1 ? '' : rawKey.slice(semi + 1)
 
     switch (name) {
       case 'UID':
-        current.uid = value.trim()
-        break
+        current.uid = value.trim(); break
       case 'SUMMARY':
-        current.summary = unescapeText(value)
-        break
+        current.summary = unescapeText(value); break
       case 'DESCRIPTION':
-        current.description = unescapeText(value)
-        break
+        current.description = unescapeText(value); break
       case 'LOCATION':
-        current.location = unescapeText(value)
-        break
+        // Strip CR/LF artifacts before unescape (line-folding bleed-through).
+        current.location = unescapeText(value.replace(/[\r\n]+/g, ' ').trim()); break
+      case 'STATUS':
+        current.status = value.trim().toUpperCase() as ParsedVEvent['status']; break
+      case 'ATTENDEE':
+        // Keep the full property line (including PARTSTAT params) so the
+        // declined-filter above can read it.
+        current.attendees!.push(`${rawKey}:${value}`); break
       case 'DTSTART': {
         const parsed = parseIcsDate(value, params)
         current.startAt = parsed.iso
         current.isAllDay = parsed.isAllDay
+        current.startTzid = parsed.tzid
         break
       }
       case 'DTEND': {
@@ -91,13 +130,96 @@ export function parseIcs(raw: string): IcsEvent[] {
         current.endAt = parsed.iso
         break
       }
+      case 'RRULE':
+        current.rrule = parseRRule(value); break
+      case 'EXDATE': {
+        // EXDATE may appear multiple times AND carry comma-separated values.
+        for (const part of value.split(',')) {
+          const parsed = parseIcsDate(part, params)
+          current.exdates!.push(parsed.iso)
+        }
+        break
+      }
+      case 'RECURRENCE-ID': {
+        const parsed = parseIcsDate(value, params)
+        current.recurrenceId = parsed.iso
+        break
+      }
     }
   }
-  return events
+
+  // Materialize masters → concrete IcsEvents within the window.
+  const collected: IcsEvent[] = []
+  for (const m of masters) {
+    if (!m.rrule) {
+      if (m.startAt > windowEnd) continue
+      // Use endAt if present, else fall back to startAt (event without DTEND
+      // is treated as a point in time, not "open until end of universe").
+      const effectiveEnd = m.endAt ?? m.startAt
+      if (effectiveEnd < windowStart) continue
+      collected.push(toIcsEvent(m))
+      continue
+    }
+    const instances = expandRrule(m, windowStart, windowEnd)
+    for (const inst of instances) {
+      const overrideKey = `${m.uid}|${inst.startAt}`
+      const override = overrides.get(overrideKey)
+      if (override) {
+        if (override.status === 'CANCELLED') continue  // override cancelled this instance
+        if (override.startAt > windowEnd) continue
+        collected.push(toIcsEvent(override))
+      } else {
+        collected.push(toIcsEvent(inst))
+      }
+    }
+  }
+
+  // Dedup by (summary, startAt). Some calendars emit the same event under
+  // multiple UIDs (e.g. a recurring meeting copied between two calendars
+  // both subscribed to). Keep first occurrence.
+  const seen = new Set<string>()
+  const out: IcsEvent[] = []
+  for (const ev of collected) {
+    const key = `${ev.summary}|${ev.startAt}`
+    if (seen.has(key)) continue
+    seen.add(key)
+    out.push(ev)
+  }
+  // Sort chronologically.
+  out.sort((a, b) => a.startAt.localeCompare(b.startAt))
+  return out
 }
 
-// RFC 5545 §3.1 — a CRLF followed by a single linear-white-space char
-// (space or tab) is a continuation of the prior line.
+interface ParsedVEvent {
+  uid: string
+  summary?: string
+  description?: string | null
+  location?: string | null
+  startAt: string
+  endAt?: string | null
+  isAllDay: boolean
+  startTzid?: string  // for duration math when expanding RRULE
+  rrule?: RRule | null
+  exdates?: string[]
+  recurrenceId?: string
+  status?: 'CONFIRMED' | 'CANCELLED' | 'TENTATIVE'
+  attendees?: string[]  // raw ATTENDEE property lines for PARTSTAT inspection
+}
+
+function toIcsEvent(p: ParsedVEvent): IcsEvent {
+  return {
+    uid: p.uid,
+    summary: p.summary ?? '(no title)',
+    description: p.description ?? null,
+    location: p.location ?? null,
+    startAt: p.startAt,
+    endAt: p.endAt ?? null,
+    isAllDay: p.isAllDay,
+  }
+}
+
+// ─── Line handling ──────────────────────────────────────────────────────
+
 function unfoldLines(raw: string): string[] {
   const lines = raw.replace(/\r\n/g, '\n').split('\n')
   const out: string[] = []
@@ -120,12 +242,56 @@ function unescapeText(v: string): string {
     .replace(/\\\\/g, '\\')
 }
 
-interface ParsedDate { iso: string; isAllDay: boolean }
+// Match the longest URL for each provider. Picks the longest because
+// ICS line-folding can leave shorter truncated copies in the description.
+const MEETING_URL_PATTERNS: RegExp[] = [
+  /https:\/\/[a-zA-Z0-9.-]*zoom\.us\/j\/[^\s<>"'\\]+/g,
+  /https:\/\/teams\.microsoft\.com\/[^\s<>"'\\]+/g,
+  /https:\/\/meet\.google\.com\/[^\s<>"'\\]+/g,
+]
 
-// DTSTART value forms:
-//   20260427T143000Z        — UTC instant
-//   20260427T143000         — floating local (with TZID param)
-//   20260427                — date-only (all-day, requires VALUE=DATE param)
+function enrichLocation(location: string | null, description: string | null): string | null {
+  // If LOCATION already has a URL, just clean it.
+  if (location && /^https?:\/\//i.test(location)) {
+    return cleanMeetingUrl(location)
+  }
+  // Otherwise look for a meeting URL in the description.
+  if (description) {
+    for (const pattern of MEETING_URL_PATTERNS) {
+      const matches = description.match(pattern)
+      if (matches && matches.length > 0) {
+        // Pick the longest (avoids truncated copies from line-folding).
+        const longest = matches.reduce((a, b) => a.length >= b.length ? a : b)
+        return cleanMeetingUrl(longest.replace(/[.,;:\\]+$/, ''))
+      }
+    }
+  }
+  return location
+}
+
+// Strip Google Calendar redirect tracking + percent-encoding artifacts.
+// Mirrors Peripheral Brain's fetch_calendar.py:495-514.
+function cleanMeetingUrl(url: string): string {
+  let u = url
+    .replace(/\\;/g, ';')
+    .replace(/&amp;/g, '&')
+    .replace(/&amp/g, '&')
+  for (const marker of ['&sa=D', ';sa=D', '%26sa%3DD']) {
+    const idx = u.indexOf(marker)
+    if (idx > 0) u = u.slice(0, idx)
+  }
+  // Decode percent-encoded query string.
+  if (u.includes('?')) {
+    const [base, qs] = u.split('?', 2)
+    try { u = `${base}?${decodeURIComponent(qs)}` } catch { /* leave encoded */ }
+  }
+  return u.replace(/[&;,\s]+$/, '')
+}
+
+// ─── Date parsing ───────────────────────────────────────────────────────
+
+interface ParsedDate { iso: string; isAllDay: boolean; tzid?: string }
+
 function parseIcsDate(value: string, params: string): ParsedDate {
   const v = value.trim()
   const isAllDay = /VALUE=DATE(?!-TIME)/i.test(params) || /^\d{8}$/.test(v)
@@ -135,20 +301,316 @@ function parseIcsDate(value: string, params: string): ParsedDate {
     return { iso: `${y}-${m}-${d}T00:00:00.000Z`, isAllDay: true }
   }
 
+  // UTC instant — has Z suffix.
   const utc = /^(\d{8})T(\d{6})Z$/.exec(v)
   if (utc) {
-    const [_, ymd, hms] = utc
-    return { iso: `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}T${hms.slice(0, 2)}:${hms.slice(2, 4)}:${hms.slice(4, 6)}.000Z`, isAllDay: false }
+    const [, ymd, hms] = utc
+    return { iso: composeIso(ymd, hms, 0), isAllDay: false }
   }
 
+  // Floating local — may have TZID param.
   const local = /^(\d{8})T(\d{6})$/.exec(v)
   if (local) {
-    // Floating local — without IANA tz data we treat as UTC wall-clock.
-    // See module header for tradeoff.
-    const [_, ymd, hms] = local
-    return { iso: `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}T${hms.slice(0, 2)}:${hms.slice(2, 4)}:${hms.slice(4, 6)}.000Z`, isAllDay: false }
+    const [, ymd, hms] = local
+    const tzidMatch = /TZID=([^;:]+)/i.exec(params)
+    const tzid = tzidMatch ? tzidMatch[1] : undefined
+    if (tzid) {
+      const offsetMin = tzOffsetMinutes(tzid, ymd, hms)
+      return { iso: composeIso(ymd, hms, offsetMin), isAllDay: false, tzid }
+    }
+    // True floating (no TZID) — treat as UTC, RFC 5545 leaves this to the
+    // calendar consumer's local time. We can't know the user's tz on the
+    // server, so UTC is the only deterministic choice.
+    return { iso: composeIso(ymd, hms, 0), isAllDay: false }
   }
 
-  // Fallback: leave as-is so caller can see and discard
   return { iso: v, isAllDay: false }
+}
+
+// Build a UTC ISO string from local YYYYMMDD + HHMMSS + offsetMinutes
+// (offset is target-tz minus UTC, e.g. America/Chicago in DST = -300).
+// We add the offset to the local wall-clock to get UTC.
+function composeIso(ymd: string, hms: string, offsetMin: number): string {
+  const y = +ymd.slice(0, 4), mo = +ymd.slice(4, 6), d = +ymd.slice(6, 8)
+  const h = +hms.slice(0, 2), mi = +hms.slice(2, 4), s = +hms.slice(4, 6)
+  // Date.UTC interprets args as UTC. Adding offsetMin minutes flips
+  // wall-clock-in-tzid to actual UTC instant.
+  const ms = Date.UTC(y, mo - 1, d, h, mi, s) - offsetMin * 60_000
+  return new Date(ms).toISOString()
+}
+
+// Resolve the UTC offset of an IANA timezone at a given wall-clock instant.
+// Workers ship with tz data via Intl.DateTimeFormat. Returns minutes
+// (negative for west of UTC, e.g. America/Chicago CST = -360, CDT = -300).
+//
+// Cached because parsing one calendar usually involves hundreds of
+// lookups against the same TZID + nearby dates, and Intl construction is
+// the slow step.
+const tzOffsetCache = new Map<string, number>()
+
+function tzOffsetMinutes(tzid: string, ymd: string, hms: string): number {
+  const cacheKey = `${tzid}|${ymd}|${hms.slice(0, 4)}`  // hour granularity is enough
+  const cached = tzOffsetCache.get(cacheKey)
+  if (cached !== undefined) return cached
+
+  try {
+    const y = +ymd.slice(0, 4), mo = +ymd.slice(4, 6), d = +ymd.slice(6, 8)
+    const h = +hms.slice(0, 2), mi = +hms.slice(2, 4)
+    // Probe instant: treat the wall-clock as UTC, then ask Intl what the
+    // target tz says it is. The difference is the offset.
+    const probeUtc = Date.UTC(y, mo - 1, d, h, mi, 0)
+    const fmt = new Intl.DateTimeFormat('en-US', {
+      timeZone: tzid,
+      year: 'numeric', month: '2-digit', day: '2-digit',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+      hour12: false,
+    })
+    const parts = fmt.formatToParts(new Date(probeUtc))
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? '0'
+    const py = +get('year'), pmo = +get('month'), pd = +get('day')
+    const ph = +get('hour') === 24 ? 0 : +get('hour')  // some locales return 24
+    const pmi = +get('minute'), ps = +get('second')
+    const tzWall = Date.UTC(py, pmo - 1, pd, ph, pmi, ps)
+    // tzWall - probeUtc = how much the target tz is ahead of UTC.
+    const offsetMin = Math.round((tzWall - probeUtc) / 60_000)
+    tzOffsetCache.set(cacheKey, offsetMin)
+    return offsetMin
+  } catch {
+    // Unknown TZID (e.g. Outlook's "Eastern Standard Time" rather than
+    // IANA "America/New_York"). Fall back to UTC — better than throwing.
+    tzOffsetCache.set(cacheKey, 0)
+    return 0
+  }
+}
+
+// ─── RRULE ──────────────────────────────────────────────────────────────
+
+interface RRule {
+  freq: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'YEARLY'
+  interval: number
+  count?: number
+  until?: string  // ISO
+  byDay?: string[]  // MO, TU, WE, ... possibly prefixed e.g. "1MO" (first Monday)
+  byMonthDay?: number[]
+  byMonth?: number[]
+  bySetPos?: number[]
+  weekStart?: 'MO' | 'SU'
+}
+
+function parseRRule(value: string): RRule | null {
+  const parts = value.split(';')
+  const out: Partial<RRule> = { interval: 1, weekStart: 'MO' }
+  for (const p of parts) {
+    const eq = p.indexOf('=')
+    if (eq === -1) continue
+    const k = p.slice(0, eq).toUpperCase()
+    const v = p.slice(eq + 1)
+    switch (k) {
+      case 'FREQ':
+        if (v === 'DAILY' || v === 'WEEKLY' || v === 'MONTHLY' || v === 'YEARLY') out.freq = v
+        break
+      case 'INTERVAL':
+        out.interval = Math.max(1, parseInt(v, 10) || 1); break
+      case 'COUNT':
+        out.count = parseInt(v, 10); break
+      case 'UNTIL': {
+        // UNTIL is either a date or UTC instant. Common pattern from Google:
+        // UNTIL=YYYYMMDDT055959Z = "ends previous day 11:59 PM Central". The
+        // Python TODAY.md generator handles this by treating early-UTC UNTIL
+        // as previous-day end. Replicate that heuristic.
+        const utc = /^(\d{8})T(\d{6})Z$/.exec(v)
+        if (utc) {
+          const [, ymd, hms] = utc
+          const hour = parseInt(hms.slice(0, 2), 10)
+          if (hour < 12) {
+            // Roll back to end of previous day in UTC.
+            const prev = new Date(Date.UTC(+ymd.slice(0, 4), +ymd.slice(4, 6) - 1, +ymd.slice(6, 8)) - 1)
+            out.until = prev.toISOString()
+          } else {
+            out.until = composeIso(ymd, hms, 0)
+          }
+        } else if (/^\d{8}$/.test(v)) {
+          out.until = `${v.slice(0, 4)}-${v.slice(4, 6)}-${v.slice(6, 8)}T23:59:59.000Z`
+        }
+        break
+      }
+      case 'BYDAY':
+        out.byDay = v.split(',').map((s) => s.trim().toUpperCase()); break
+      case 'BYMONTHDAY':
+        out.byMonthDay = v.split(',').map((s) => parseInt(s, 10)).filter((n) => !isNaN(n)); break
+      case 'BYMONTH':
+        out.byMonth = v.split(',').map((s) => parseInt(s, 10)).filter((n) => !isNaN(n)); break
+      case 'BYSETPOS':
+        out.bySetPos = v.split(',').map((s) => parseInt(s, 10)).filter((n) => !isNaN(n)); break
+      case 'WKST':
+        out.weekStart = (v === 'SU' ? 'SU' : 'MO'); break
+    }
+  }
+  if (!out.freq) return null
+  return out as RRule
+}
+
+const DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'] as const
+
+function expandRrule(master: ParsedVEvent, windowStart: string, windowEnd: string): ParsedVEvent[] {
+  const r = master.rrule!
+  const out: ParsedVEvent[] = []
+  const exdates = new Set(master.exdates ?? [])
+  const startMs = new Date(master.startAt).getTime()
+  const endMs = master.endAt ? new Date(master.endAt).getTime() : null
+  const durationMs = endMs ? endMs - startMs : null
+
+  // Hard caps so a malformed RRULE can't run forever.
+  const HARD_MAX_INSTANCES = 1000
+  const windowEndMs = new Date(windowEnd).getTime()
+  const windowStartMs = new Date(windowStart).getTime()
+  const untilMs = r.until ? new Date(r.until).getTime() : null
+
+  let count = 0
+  let cursor = new Date(startMs)
+
+  while (true) {
+    if (count >= HARD_MAX_INSTANCES) break
+    if (r.count !== undefined && count >= r.count) break
+    if (untilMs !== null && cursor.getTime() > untilMs) break
+    if (cursor.getTime() > windowEndMs) break
+
+    // Generate the candidate instances at this cursor position. For
+    // DAILY/WEEKLY this is typically 1 instance; for MONTHLY/YEARLY with
+    // BYDAY+BYSETPOS it's the matching weekday(s) within the period.
+    const candidates = generateCandidates(cursor, r)
+
+    for (const candMs of candidates) {
+      if (untilMs !== null && candMs > untilMs) break
+      if (candMs > windowEndMs) break
+      if (candMs < windowStartMs && (durationMs === null || candMs + durationMs < windowStartMs)) {
+        // Before the window. Still counts toward COUNT.
+        if (r.count !== undefined && ++count >= r.count) return out
+        continue
+      }
+      const startIso = new Date(candMs).toISOString()
+      if (exdates.has(startIso)) {
+        if (r.count !== undefined && ++count >= r.count) return out
+        continue
+      }
+      const endIso = durationMs !== null ? new Date(candMs + durationMs).toISOString() : null
+      out.push({
+        uid: master.uid,
+        summary: master.summary,
+        description: master.description,
+        location: master.location,
+        startAt: startIso,
+        endAt: endIso,
+        isAllDay: master.isAllDay,
+      })
+      count++
+      if (r.count !== undefined && count >= r.count) return out
+    }
+
+    cursor = advanceCursor(cursor, r)
+  }
+  return out
+}
+
+// Generate all candidate instances in the current period defined by cursor.
+// Returns ms timestamps.
+function generateCandidates(cursor: Date, r: RRule): number[] {
+  if (r.freq === 'DAILY') {
+    return [cursor.getTime()]
+  }
+  if (r.freq === 'WEEKLY') {
+    if (!r.byDay || r.byDay.length === 0) return [cursor.getTime()]
+    // Cursor anchors the week start. Pick the days in r.byDay within
+    // 7 days starting at cursor.
+    const out: number[] = []
+    const baseDow = cursor.getUTCDay()  // 0=Sunday
+    for (const code of r.byDay) {
+      const dayCode = code.slice(-2)
+      const idx = DAY_CODES.indexOf(dayCode as typeof DAY_CODES[number])
+      if (idx === -1) continue
+      const delta = (idx - baseDow + 7) % 7
+      out.push(cursor.getTime() + delta * 86400000)
+    }
+    return out.sort((a, b) => a - b)
+  }
+  if (r.freq === 'MONTHLY') {
+    return monthlyCandidates(cursor, r)
+  }
+  if (r.freq === 'YEARLY') {
+    // Compose: filter by BYMONTH (if present) then apply MONTHLY-style logic.
+    const months = r.byMonth ?? [cursor.getUTCMonth() + 1]
+    const out: number[] = []
+    for (const m of months) {
+      const periodStart = new Date(Date.UTC(cursor.getUTCFullYear(), m - 1, 1, cursor.getUTCHours(), cursor.getUTCMinutes(), cursor.getUTCSeconds()))
+      out.push(...monthlyCandidates(periodStart, r))
+    }
+    return out.sort((a, b) => a - b)
+  }
+  return []
+}
+
+function monthlyCandidates(periodStart: Date, r: RRule): number[] {
+  const y = periodStart.getUTCFullYear()
+  const mo = periodStart.getUTCMonth()
+  const hh = periodStart.getUTCHours()
+  const mm = periodStart.getUTCMinutes()
+  const ss = periodStart.getUTCSeconds()
+  const daysInMonth = new Date(Date.UTC(y, mo + 1, 0)).getUTCDate()
+
+  if (r.byMonthDay && r.byMonthDay.length > 0) {
+    return r.byMonthDay
+      .map((d) => d > 0 ? d : daysInMonth + d + 1)
+      .filter((d) => d >= 1 && d <= daysInMonth)
+      .map((d) => Date.UTC(y, mo, d, hh, mm, ss))
+      .sort((a, b) => a - b)
+  }
+
+  if (r.byDay && r.byDay.length > 0) {
+    // BYDAY may carry "1MO" (first Monday), "-1FR" (last Friday), or bare "MO".
+    const all: { day: number; dayMs: number }[] = []
+    for (const code of r.byDay) {
+      const m = /^(-?\d+)?([A-Z]{2})$/.exec(code)
+      if (!m) continue
+      const ordinal = m[1] ? parseInt(m[1], 10) : null
+      const dayCode = m[2]
+      const targetDow = DAY_CODES.indexOf(dayCode as typeof DAY_CODES[number])
+      if (targetDow === -1) continue
+      const matches: number[] = []
+      for (let day = 1; day <= daysInMonth; day++) {
+        const dt = new Date(Date.UTC(y, mo, day, hh, mm, ss))
+        if (dt.getUTCDay() === targetDow) matches.push(day)
+      }
+      if (ordinal === null) {
+        for (const day of matches) all.push({ day, dayMs: Date.UTC(y, mo, day, hh, mm, ss) })
+      } else {
+        const idx = ordinal > 0 ? ordinal - 1 : matches.length + ordinal
+        const day = matches[idx]
+        if (day) all.push({ day, dayMs: Date.UTC(y, mo, day, hh, mm, ss) })
+      }
+    }
+    let result = all.map((a) => a.dayMs).sort((a, b) => a - b)
+    if (r.bySetPos && r.bySetPos.length > 0) {
+      result = r.bySetPos.map((p) => p > 0 ? result[p - 1] : result[result.length + p]).filter((x) => x !== undefined)
+    }
+    return result
+  }
+
+  // No BYMONTHDAY or BYDAY: the master DTSTART day repeats at the same day of month.
+  const dom = Math.min(periodStart.getUTCDate(), daysInMonth)
+  return [Date.UTC(y, mo, dom, hh, mm, ss)]
+}
+
+function advanceCursor(cursor: Date, r: RRule): Date {
+  const next = new Date(cursor.getTime())
+  switch (r.freq) {
+    case 'DAILY':
+      next.setUTCDate(next.getUTCDate() + r.interval); break
+    case 'WEEKLY':
+      next.setUTCDate(next.getUTCDate() + 7 * r.interval); break
+    case 'MONTHLY':
+      next.setUTCMonth(next.getUTCMonth() + r.interval); break
+    case 'YEARLY':
+      next.setUTCFullYear(next.getUTCFullYear() + r.interval); break
+  }
+  return next
 }

--- a/api/lib/ics-parser.ts
+++ b/api/lib/ics-parser.ts
@@ -1,0 +1,154 @@
+// Minimal iCalendar (RFC 5545) VEVENT parser. Pure JS, no deps — runs in
+// Cloudflare Workers without Node polyfills. Handles the subset Google /
+// Outlook / iCloud actually emit:
+//   - VEVENT blocks (ignores VTODO, VJOURNAL, VTIMEZONE, etc.)
+//   - DTSTART / DTEND with optional TZID= or VALUE=DATE (all-day)
+//   - SUMMARY, UID, LOCATION, DESCRIPTION
+//   - Line unfolding (RFC 5545 §3.1: CRLF + space/tab continues prior line)
+//   - Basic backslash escapes (\\n, \\,, \\;, \\\\)
+//   - RRULE expansion: NOT supported. Recurring events surface only their
+//     master DTSTART; recurrences within the polling window are missed.
+//     This is acceptable for a 15-min cache feeding a "today timeline" —
+//     fix when someone reports a missing weekly meeting. (TODO #45-followup)
+//
+// TZID handling: Workers have no IANA timezone DB. We treat TZID values as
+// hints and parse the local time as wall-clock; output is the wall-clock
+// converted naively to UTC. Practical impact: all-day events render
+// correctly; timed events drift by the user's UTC offset only when the
+// server-side conversion matters (e.g., today-vs-tomorrow at midnight
+// boundaries). Acceptable for v1; document limitation.
+
+export interface IcsEvent {
+  uid: string
+  summary: string
+  description: string | null
+  location: string | null
+  startAt: string  // ISO-8601, UTC if known, else wall-clock + 'Z'
+  endAt: string | null
+  isAllDay: boolean
+}
+
+export function parseIcs(raw: string): IcsEvent[] {
+  const unfolded = unfoldLines(raw)
+  const events: IcsEvent[] = []
+  let current: Partial<IcsEvent> | null = null
+  let inEvent = false
+
+  for (const line of unfolded) {
+    if (line === 'BEGIN:VEVENT') {
+      inEvent = true
+      current = {}
+      continue
+    }
+    if (line === 'END:VEVENT') {
+      if (current && current.uid && current.startAt) {
+        events.push({
+          uid: current.uid,
+          summary: current.summary ?? '(no title)',
+          description: current.description ?? null,
+          location: current.location ?? null,
+          startAt: current.startAt,
+          endAt: current.endAt ?? null,
+          isAllDay: current.isAllDay ?? false,
+        })
+      }
+      current = null
+      inEvent = false
+      continue
+    }
+    if (!inEvent || !current) continue
+
+    const colon = line.indexOf(':')
+    if (colon === -1) continue
+    const rawKey = line.slice(0, colon)
+    const value = line.slice(colon + 1)
+    // Property name may carry params: DTSTART;TZID=America/Chicago:...
+    const semi = rawKey.indexOf(';')
+    const name = (semi === -1 ? rawKey : rawKey.slice(0, semi)).toUpperCase()
+    const params = semi === -1 ? '' : rawKey.slice(semi + 1)
+
+    switch (name) {
+      case 'UID':
+        current.uid = value.trim()
+        break
+      case 'SUMMARY':
+        current.summary = unescapeText(value)
+        break
+      case 'DESCRIPTION':
+        current.description = unescapeText(value)
+        break
+      case 'LOCATION':
+        current.location = unescapeText(value)
+        break
+      case 'DTSTART': {
+        const parsed = parseIcsDate(value, params)
+        current.startAt = parsed.iso
+        current.isAllDay = parsed.isAllDay
+        break
+      }
+      case 'DTEND': {
+        const parsed = parseIcsDate(value, params)
+        current.endAt = parsed.iso
+        break
+      }
+    }
+  }
+  return events
+}
+
+// RFC 5545 §3.1 — a CRLF followed by a single linear-white-space char
+// (space or tab) is a continuation of the prior line.
+function unfoldLines(raw: string): string[] {
+  const lines = raw.replace(/\r\n/g, '\n').split('\n')
+  const out: string[] = []
+  for (const line of lines) {
+    if (line.length === 0) continue
+    if ((line[0] === ' ' || line[0] === '\t') && out.length > 0) {
+      out[out.length - 1] += line.slice(1)
+    } else {
+      out.push(line)
+    }
+  }
+  return out
+}
+
+function unescapeText(v: string): string {
+  return v
+    .replace(/\\n/gi, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\')
+}
+
+interface ParsedDate { iso: string; isAllDay: boolean }
+
+// DTSTART value forms:
+//   20260427T143000Z        — UTC instant
+//   20260427T143000         — floating local (with TZID param)
+//   20260427                — date-only (all-day, requires VALUE=DATE param)
+function parseIcsDate(value: string, params: string): ParsedDate {
+  const v = value.trim()
+  const isAllDay = /VALUE=DATE(?!-TIME)/i.test(params) || /^\d{8}$/.test(v)
+
+  if (isAllDay && /^\d{8}$/.test(v)) {
+    const y = v.slice(0, 4), m = v.slice(4, 6), d = v.slice(6, 8)
+    return { iso: `${y}-${m}-${d}T00:00:00.000Z`, isAllDay: true }
+  }
+
+  const utc = /^(\d{8})T(\d{6})Z$/.exec(v)
+  if (utc) {
+    const [_, ymd, hms] = utc
+    return { iso: `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}T${hms.slice(0, 2)}:${hms.slice(2, 4)}:${hms.slice(4, 6)}.000Z`, isAllDay: false }
+  }
+
+  const local = /^(\d{8})T(\d{6})$/.exec(v)
+  if (local) {
+    // Floating local — without IANA tz data we treat as UTC wall-clock.
+    // See module header for tradeoff.
+    const [_, ymd, hms] = local
+    return { iso: `${ymd.slice(0, 4)}-${ymd.slice(4, 6)}-${ymd.slice(6, 8)}T${hms.slice(0, 2)}:${hms.slice(2, 4)}:${hms.slice(4, 6)}.000Z`, isAllDay: false }
+  }
+
+  // Fallback: leave as-is so caller can see and discard
+  return { iso: v, isAllDay: false }
+}

--- a/api/routes/calendar-feeds.ts
+++ b/api/routes/calendar-feeds.ts
@@ -1,0 +1,217 @@
+// Personal calendar iCal feed endpoints. Issue #45.
+//
+// Each user can paste a private iCal URL (Google "Secret address in iCal
+// format", Outlook publish, iCloud share). Hub stores the URL, polls it
+// lazily on Today page load (when last_polled_at >15min stale), parses
+// VEVENTs, and serves them back per-user / per-date.
+//
+// The feed URL itself is the secret. We never return it through GET —
+// only an obfuscated host preview ("calendar.google.com/...") so users
+// can confirm what they pasted without it being copyable from devtools.
+
+import type { Env, AuthUser } from '../helpers'
+import { json, error } from '../helpers'
+import { actorSlug } from '../helpers'
+import { parseIcs, type IcsEvent } from '../lib/ics-parser'
+
+const STALE_MINUTES = 15
+const FETCH_TIMEOUT_MS = 8000
+
+interface FeedRow {
+  id: string
+  user_slug: string
+  feed_url: string
+  feed_label: string
+  last_polled_at: string | null
+  last_error: string | null
+  created_at: string
+}
+
+function newId(): string {
+  // 32-char hex like other Hub-created entities (matches tasks/projects).
+  const a = new Uint8Array(16)
+  crypto.getRandomValues(a)
+  return Array.from(a, (b) => b.toString(16).padStart(2, '0')).join('')
+}
+
+function obfuscateUrl(u: string): string {
+  try {
+    const url = new URL(u)
+    const path = url.pathname
+    const tail = path.length > 16 ? `…${path.slice(-12)}` : path
+    return `${url.host}${tail}`
+  } catch { return 'invalid url' }
+}
+
+function sanitizeUrl(raw: string): string | null {
+  const trimmed = raw.trim()
+  if (!trimmed) return null
+  // webcal:// is iCloud's preferred scheme — equivalent to https for our
+  // purposes (it's just a hint to native calendar apps). Rewrite so fetch()
+  // accepts it.
+  const normalized = trimmed.replace(/^webcal:\/\//i, 'https://')
+  try {
+    const u = new URL(normalized)
+    if (u.protocol !== 'http:' && u.protocol !== 'https:') return null
+    return u.toString()
+  } catch { return null }
+}
+
+// GET /api/integrations/calendar/feeds — list current user's feeds
+export async function handleListFeeds(env: Env, user: AuthUser | null): Promise<Response> {
+  if (!user) return error('Unauthorized', 401)
+  const slug = actorSlug(user.email)
+  const r = await env.DB.prepare(
+    'SELECT id, user_slug, feed_url, feed_label, last_polled_at, last_error, created_at FROM user_calendar_feeds WHERE user_slug = ? ORDER BY created_at'
+  ).bind(slug).all<FeedRow>()
+  const feeds = (r.results ?? []).map((row) => ({
+    id: row.id,
+    label: row.feed_label,
+    urlPreview: obfuscateUrl(row.feed_url),
+    lastPolledAt: row.last_polled_at,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+  }))
+  return json({ feeds })
+}
+
+// POST /api/integrations/calendar/feeds — body: { url, label? }
+export async function handleAddFeed(request: Request, env: Env, user: AuthUser | null): Promise<Response> {
+  if (!user) return error('Unauthorized', 401)
+  const slug = actorSlug(user.email)
+  const body = await request.json().catch(() => null) as { url?: string; label?: string } | null
+  if (!body) return error('Invalid JSON body', 400)
+  const url = sanitizeUrl(body.url ?? '')
+  if (!url) return error('Invalid iCal URL — must be http(s) or webcal', 400)
+  const label = (body.label ?? '').trim().slice(0, 64) || 'Primary'
+
+  const id = newId()
+  try {
+    await env.DB.prepare(
+      'INSERT INTO user_calendar_feeds (id, user_slug, feed_url, feed_label) VALUES (?, ?, ?, ?)'
+    ).bind(id, slug, url, label).run()
+  } catch (e) {
+    const msg = (e as Error).message
+    if (msg.includes('UNIQUE')) return error('Feed already added', 409)
+    throw e
+  }
+
+  // Eager poll on add so the user sees events immediately. Best-effort —
+  // failures land in last_error and surface in the Settings UI.
+  await pollFeed(env, { id, user_slug: slug, feed_url: url, feed_label: label, last_polled_at: null, last_error: null, created_at: new Date().toISOString() })
+
+  return json({ id, label, urlPreview: obfuscateUrl(url) }, 201)
+}
+
+// DELETE /api/integrations/calendar/feeds/:id
+export async function handleDeleteFeed(env: Env, user: AuthUser | null, id: string): Promise<Response> {
+  if (!user) return error('Unauthorized', 401)
+  const slug = actorSlug(user.email)
+  // Confirm ownership before delete (FK cascade clears events automatically).
+  const row = await env.DB.prepare('SELECT user_slug FROM user_calendar_feeds WHERE id = ?').bind(id).first<{ user_slug: string }>()
+  if (!row) return error('Feed not found', 404)
+  if (row.user_slug !== slug) return error('Forbidden', 403)
+  await env.DB.prepare('DELETE FROM user_calendar_feeds WHERE id = ?').bind(id).run()
+  return json({ ok: true })
+}
+
+// GET /api/integrations/calendar/events?start=YYYY-MM-DD&end=YYYY-MM-DD
+// Refreshes any stale feeds (>15min) before returning.
+export async function handleListEvents(url: URL, env: Env, user: AuthUser | null): Promise<Response> {
+  if (!user) return error('Unauthorized', 401)
+  const slug = actorSlug(user.email)
+  const start = url.searchParams.get('start') || new Date().toISOString().slice(0, 10)
+  // Default range: today + next 7 days.
+  const endDefault = new Date(Date.now() + 7 * 86400000).toISOString().slice(0, 10)
+  const end = url.searchParams.get('end') || endDefault
+
+  const feeds = await env.DB.prepare(
+    'SELECT id, user_slug, feed_url, feed_label, last_polled_at, last_error, created_at FROM user_calendar_feeds WHERE user_slug = ?'
+  ).bind(slug).all<FeedRow>()
+
+  // Refresh stale feeds in parallel. Don't block on errors — stale data
+  // beats no data, last_error surfaces in Settings.
+  const stalenessCutoff = new Date(Date.now() - STALE_MINUTES * 60_000).toISOString()
+  const stale = (feeds.results ?? []).filter((f) => !f.last_polled_at || f.last_polled_at < stalenessCutoff)
+  if (stale.length > 0) {
+    await Promise.allSettled(stale.map((f) => pollFeed(env, f)))
+  }
+
+  // Range query is inclusive on both ends. start_at is ISO with 'Z' suffix
+  // so a string compare against `${start}T00:00:00.000Z` works naturally.
+  const startBound = `${start}T00:00:00.000Z`
+  const endBound = `${end}T23:59:59.999Z`
+  const rows = await env.DB.prepare(
+    `SELECT id, summary, location, start_at, end_at, is_all_day
+     FROM user_calendar_events
+     WHERE user_slug = ? AND start_at >= ? AND start_at <= ?
+     ORDER BY start_at`
+  ).bind(slug, startBound, endBound).all<{ id: string; summary: string | null; location: string | null; start_at: string; end_at: string | null; is_all_day: number }>()
+
+  const events = (rows.results ?? []).map((r) => ({
+    id: r.id,
+    title: r.summary ?? '(no title)',
+    location: r.location,
+    startAt: r.start_at,
+    endAt: r.end_at,
+    isAllDay: r.is_all_day === 1,
+  }))
+  return json({ events, refreshedFeeds: stale.length })
+}
+
+// Internal: poll a single feed, parse, upsert events, update last_polled_at.
+async function pollFeed(env: Env, feed: FeedRow): Promise<void> {
+  let body = ''
+  try {
+    const ctrl = new AbortController()
+    const timer = setTimeout(() => ctrl.abort(), FETCH_TIMEOUT_MS)
+    const res = await fetch(feed.feed_url, {
+      headers: { 'User-Agent': 'mn-ccore-lab-hub/1.0 (calendar-feed-poller)' },
+      signal: ctrl.signal,
+      cf: { cacheTtl: 0, cacheEverything: false },
+    } as RequestInit)
+    clearTimeout(timer)
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    body = await res.text()
+    if (!body.includes('BEGIN:VCALENDAR')) throw new Error('Response not iCalendar')
+  } catch (e) {
+    const msg = (e as Error).message.slice(0, 200)
+    await env.DB.prepare(
+      'UPDATE user_calendar_feeds SET last_polled_at = ?, last_error = ? WHERE id = ?'
+    ).bind(new Date().toISOString(), msg, feed.id).run()
+    return
+  }
+
+  let parsed: IcsEvent[]
+  try {
+    parsed = parseIcs(body)
+  } catch (e) {
+    await env.DB.prepare(
+      'UPDATE user_calendar_feeds SET last_polled_at = ?, last_error = ? WHERE id = ?'
+    ).bind(new Date().toISOString(), `parse: ${(e as Error).message.slice(0, 180)}`, feed.id).run()
+    return
+  }
+
+  // Only retain events whose start falls within today-7 .. today+90. Calendar
+  // feeds often carry years of history that we don't need on a Today timeline.
+  const minDate = new Date(Date.now() - 7 * 86400000).toISOString()
+  const maxDate = new Date(Date.now() + 90 * 86400000).toISOString()
+  const inWindow = parsed.filter((e) => e.startAt >= minDate && e.startAt <= maxDate)
+
+  // Replace strategy: clear events for this feed, re-insert. Simpler than
+  // diffing UIDs, and per-feed event counts are <500 typical so the write
+  // cost is fine.
+  const stmts: D1PreparedStatement[] = []
+  stmts.push(env.DB.prepare('DELETE FROM user_calendar_events WHERE feed_id = ?').bind(feed.id))
+  for (const ev of inWindow) {
+    stmts.push(env.DB.prepare(
+      `INSERT INTO user_calendar_events (id, feed_id, user_slug, uid, summary, description, location, start_at, end_at, is_all_day, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))`
+    ).bind(newId(), feed.id, feed.user_slug, ev.uid, ev.summary, ev.description, ev.location, ev.startAt, ev.endAt, ev.isAllDay ? 1 : 0))
+  }
+  stmts.push(env.DB.prepare(
+    'UPDATE user_calendar_feeds SET last_polled_at = ?, last_error = NULL WHERE id = ?'
+  ).bind(new Date().toISOString(), feed.id))
+
+  await env.DB.batch(stmts)
+}

--- a/api/routes/calendar-feeds.ts
+++ b/api/routes/calendar-feeds.ts
@@ -12,7 +12,7 @@
 import type { Env, AuthUser } from '../helpers'
 import { json, error } from '../helpers'
 import { actorSlug } from '../helpers'
-import { parseIcs, type IcsEvent } from '../lib/ics-parser'
+import { parseIcs, type IcsEvent, type ParseOptions } from '../lib/ics-parser'
 
 const STALE_MINUTES = 15
 const FETCH_TIMEOUT_MS = 8000
@@ -98,7 +98,11 @@ export async function handleAddFeed(request: Request, env: Env, user: AuthUser |
 
   // Eager poll on add so the user sees events immediately. Best-effort —
   // failures land in last_error and surface in the Settings UI.
-  await pollFeed(env, { id, user_slug: slug, feed_url: url, feed_label: label, last_polled_at: null, last_error: null, created_at: new Date().toISOString() })
+  await pollFeed(
+    env,
+    { id, user_slug: slug, feed_url: url, feed_label: label, last_polled_at: null, last_error: null, created_at: new Date().toISOString() },
+    user.email,
+  )
 
   return json({ id, label, urlPreview: obfuscateUrl(url) }, 201)
 }
@@ -134,7 +138,7 @@ export async function handleListEvents(url: URL, env: Env, user: AuthUser | null
   const stalenessCutoff = new Date(Date.now() - STALE_MINUTES * 60_000).toISOString()
   const stale = (feeds.results ?? []).filter((f) => !f.last_polled_at || f.last_polled_at < stalenessCutoff)
   if (stale.length > 0) {
-    await Promise.allSettled(stale.map((f) => pollFeed(env, f)))
+    await Promise.allSettled(stale.map((f) => pollFeed(env, f, user.email)))
   }
 
   // Range query is inclusive on both ends. start_at is ISO with 'Z' suffix
@@ -160,7 +164,9 @@ export async function handleListEvents(url: URL, env: Env, user: AuthUser | null
 }
 
 // Internal: poll a single feed, parse, upsert events, update last_polled_at.
-async function pollFeed(env: Env, feed: FeedRow): Promise<void> {
+// ownerEmail is passed through to the parser so it can drop events the
+// user has declined (PARTSTAT=DECLINED).
+async function pollFeed(env: Env, feed: FeedRow, ownerEmail: string): Promise<void> {
   let body = ''
   try {
     const ctrl = new AbortController()
@@ -182,21 +188,23 @@ async function pollFeed(env: Env, feed: FeedRow): Promise<void> {
     return
   }
 
+  // Bound the parser's RRULE expansion to the polling window. Without a
+  // bound, an event with FREQ=DAILY and no UNTIL would expand for years.
+  const parseOpts: ParseOptions = {
+    windowStart: new Date(Date.now() - 7 * 86400000).toISOString(),
+    windowEnd: new Date(Date.now() + 90 * 86400000).toISOString(),
+    ownerEmail,
+  }
   let parsed: IcsEvent[]
   try {
-    parsed = parseIcs(body)
+    parsed = parseIcs(body, parseOpts)
   } catch (e) {
     await env.DB.prepare(
       'UPDATE user_calendar_feeds SET last_polled_at = ?, last_error = ? WHERE id = ?'
     ).bind(new Date().toISOString(), `parse: ${(e as Error).message.slice(0, 180)}`, feed.id).run()
     return
   }
-
-  // Only retain events whose start falls within today-7 .. today+90. Calendar
-  // feeds often carry years of history that we don't need on a Today timeline.
-  const minDate = new Date(Date.now() - 7 * 86400000).toISOString()
-  const maxDate = new Date(Date.now() + 90 * 86400000).toISOString()
-  const inWindow = parsed.filter((e) => e.startAt >= minDate && e.startAt <= maxDate)
+  const inWindow = parsed
 
   // Replace strategy: clear events for this feed, re-insert. Simpler than
   // diffing UIDs, and per-feed event counts are <500 typical so the write

--- a/api/schema-v52-calendar-feeds.sql
+++ b/api/schema-v52-calendar-feeds.sql
@@ -1,0 +1,50 @@
+-- v52 (2026-04-27): personal calendar feeds + cached events.
+--
+-- iCal-feed integration. Each user can paste a private iCal URL (Google,
+-- Outlook, iCloud — anything that exports the .ics format). Hub polls
+-- the URL lazily on Today page load (when last_polled_at >15min stale)
+-- and renders events alongside team meetings.
+--
+-- No OAuth, no GCP project, no Workspace verification. The URL itself
+-- is the secret — anyone with it can read the calendar — so don't expose
+-- it back through the API after save (display "configured" instead).
+--
+-- Issue #45.
+--
+-- Additive. Safe to apply to production D1.
+
+CREATE TABLE IF NOT EXISTS user_calendar_feeds (
+  id TEXT PRIMARY KEY,
+  user_slug TEXT NOT NULL,
+  feed_url TEXT NOT NULL,
+  feed_label TEXT NOT NULL DEFAULT 'Primary',
+  last_polled_at TEXT,
+  last_error TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  UNIQUE(user_slug, feed_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_calendar_feeds_user
+  ON user_calendar_feeds(user_slug);
+
+CREATE TABLE IF NOT EXISTS user_calendar_events (
+  id TEXT PRIMARY KEY,
+  feed_id TEXT NOT NULL,
+  user_slug TEXT NOT NULL,
+  uid TEXT NOT NULL,
+  summary TEXT,
+  description TEXT,
+  location TEXT,
+  start_at TEXT NOT NULL,
+  end_at TEXT,
+  is_all_day INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  FOREIGN KEY (feed_id) REFERENCES user_calendar_feeds(id) ON DELETE CASCADE,
+  UNIQUE(feed_id, uid)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_calendar_events_user_start
+  ON user_calendar_events(user_slug, start_at);
+
+CREATE INDEX IF NOT EXISTS idx_user_calendar_events_feed
+  ON user_calendar_events(feed_id);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:schema:remote": "wrangler d1 execute mnccore-lab --file=api/schema.sql --remote",
     "db:seed:remote": "wrangler d1 execute mnccore-lab --file=scripts/seed.sql --remote",
     "test": "npm run test:local",
+    "test:api": "vitest run --config vitest.config.api.ts",
     "test:local": "concurrently -k -s first \"wrangler dev api/index.ts --local --config=wrangler.local.toml --port 8787\" \"wait-on http-get://localhost:8787/api/projects && playwright test --config=playwright.config.local.ts\"",
     "test:journeys": "concurrently -k -s first \"wrangler dev api/index.ts --local --config=wrangler.local.toml --port 8787\" \"vite --port 5173\" \"wait-on http-get://localhost:5173 && playwright test --config=playwright.config.journeys.ts\"",
     "test:local:setup": "tsx scripts/local-db-bootstrap.ts && tsx scripts/local-db-seed.ts",

--- a/src/components/today/constants.ts
+++ b/src/components/today/constants.ts
@@ -156,3 +156,23 @@ export function isToday(isoDate: string | null | undefined): boolean {
   const today = todayKey()
   return isoDate.slice(0, 10) === today
 }
+
+// Personal calendar feed events (issue #45). Same TodayEvent shape so the
+// timeline renders them indistinguishably from team meetings — but we
+// prefix the title with a 📅 so users can spot which came from their feed.
+export function calendarEventToTodayEvent(e: { id: string; title: string; location: string | null; startAt: string; endAt: string | null; isAllDay: boolean }): TodayEvent {
+  const start = new Date(e.startAt)
+  const time = e.isAllDay
+    ? 'all day'
+    : start.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+  const end = e.endAt && !e.isAllDay
+    ? new Date(e.endAt).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
+    : undefined
+  return {
+    id: `cal-${e.id}`,
+    time,
+    end,
+    title: e.title,
+    loc: e.location ?? undefined,
+  }
+}

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -1505,6 +1505,34 @@ export function useUpcomingGrantMilestones(days: number = 90) {
   })
 }
 
+// ── Personal calendar feed (issue #45) ────────────────────────────────
+// Reads the current user's iCal feed events (today + next 7 days). Hub
+// poller refreshes feeds lazily on the same endpoint when last_polled_at
+// is >15min stale; first-load latency on cold cache is ~500ms-1s.
+
+export interface UserCalendarEvent {
+  id: string
+  title: string
+  location: string | null
+  startAt: string
+  endAt: string | null
+  isAllDay: boolean
+}
+
+export function useUserCalendarEvents() {
+  return useQuery({
+    queryKey: ['user-calendar-events'],
+    queryFn: async (): Promise<UserCalendarEvent[]> => {
+      const res = await fetch('/api/integrations/calendar/events')
+      if (!res.ok) return []
+      const j = await res.json() as { events: UserCalendarEvent[] }
+      return j.events
+    },
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+  })
+}
+
 // ── Conference submissions ────────────────────────────────
 
 export function useConferences(projectId: string) {

--- a/src/pages/portal/SettingsPage.tsx
+++ b/src/pages/portal/SettingsPage.tsx
@@ -674,46 +674,143 @@ function LabPrefsPanel() {
   )
 }
 
+interface CalendarFeed {
+  id: string
+  label: string
+  urlPreview: string
+  lastPolledAt: string | null
+  lastError: string | null
+  createdAt: string
+}
+
 function IntegrationsPanel() {
-  // Calendar OAuth flow not wired yet; surface the feature gap honestly so
-  // /portal/settings#integrations stops being a dead-end. Issue #45.
-  // Hub already reads team meetings from D1; this section is for personal
-  // calendar feeds (UMN Google + visiting-scientist iCloud, etc.).
+  // Personal iCal feed integration (issue #45). Each user pastes the
+  // private iCal URL from their calendar provider (Google: Settings →
+  // Integrate calendar → "Secret address in iCal format"; iCloud: share
+  // → "Public Calendar"; Outlook: publish a calendar). Hub polls the URL
+  // lazily on Today page load (>15min stale = refresh) and renders events
+  // alongside team meetings. URL stays in D1, never re-rendered after save.
+  const queryClient = useQueryClient()
+  const { data: feeds = [] } = useQuery({
+    queryKey: ['calendar-feeds'],
+    queryFn: async () => {
+      const res = await fetch('/api/integrations/calendar/feeds')
+      if (!res.ok) return [] as CalendarFeed[]
+      const j = await res.json() as { feeds: CalendarFeed[] }
+      return j.feeds
+    },
+    staleTime: 30 * 1000,
+  })
+
+  const [url, setUrl] = useState('')
+  const [label, setLabel] = useState('')
+  const [submitErr, setSubmitErr] = useState<string | null>(null)
+
+  const addFeed = useMutation({
+    mutationFn: async (input: { url: string; label: string }) => {
+      const res = await fetch('/api/integrations/calendar/feeds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(j.error ?? `HTTP ${res.status}`)
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      setUrl(''); setLabel(''); setSubmitErr(null)
+      queryClient.invalidateQueries({ queryKey: ['calendar-feeds'] })
+    },
+    onError: (e: Error) => setSubmitErr(e.message),
+  })
+
+  const removeFeed = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/api/integrations/calendar/feeds/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['calendar-feeds'] }),
+  })
+
   return (
-    <div className="flex flex-col gap-3">
-      <IntegrationCard
-        icon={CalendarIcon}
-        name="Google Calendar"
-        status="not_connected"
-        description="Pull your @umn.edu calendar onto the Today timeline. Read-only — Hub never writes back to Google."
-        ctaLabel="Connect"
-        onConnect={() => alert('Google Calendar OAuth flow not yet implemented. Tracking issue #45.')}
-      />
-      <IntegrationCard
-        icon={CalendarIcon}
-        name="iCal / .ics feed"
-        status="not_connected"
-        description="Paste a calendar URL (e.g., visiting-scientist iCloud share). Polled every 15 min."
-        ctaLabel="Add feed"
-        onConnect={() => alert('iCal feed import not yet implemented. Tracking issue #45.')}
-      />
-      <div className="flex items-start gap-2 mt-1 px-1">
+    <div className="flex flex-col gap-4">
+      {feeds.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {feeds.map((f) => (
+            <CalendarFeedRow key={f.id} feed={f} onRemove={() => removeFeed.mutate(f.id)} />
+          ))}
+        </div>
+      )}
+
+      <div
+        className="flex flex-col gap-2 p-3 rounded-lg border"
+        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+      >
+        <div className="flex items-center gap-2">
+          <CalendarIcon size={14} style={{ color: 'var(--teal)' }} />
+          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>Add a calendar feed</span>
+        </div>
+        <p className="text-[11px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>
+          Google: Settings → Integrate calendar → <em>Secret address in iCal format</em>.{' '}
+          iCloud: share calendar → <em>Public Calendar</em>.{' '}
+          Outlook: publish calendar → ICS link.{' '}
+          Read-only. Polled every ~15 min.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            type="url"
+            placeholder="https://calendar.google.com/calendar/ical/..."
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="flex-1 rounded-md border px-2 py-1.5 text-xs outline-none"
+            style={{ borderColor: 'var(--border-subtle)', color: 'var(--ink)', background: 'var(--surface-0)' }}
+          />
+          <input
+            type="text"
+            placeholder="Label (optional)"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            className="w-32 rounded-md border px-2 py-1.5 text-xs outline-none"
+            style={{ borderColor: 'var(--border-subtle)', color: 'var(--ink)', background: 'var(--surface-0)' }}
+          />
+          <button
+            type="button"
+            onClick={() => { if (url.trim()) addFeed.mutate({ url, label }) }}
+            disabled={addFeed.isPending || !url.trim()}
+            className="inline-flex items-center justify-center gap-1.5 rounded"
+            style={{
+              fontSize: 11, fontWeight: 500, padding: '6px 14px',
+              background: 'var(--teal)', border: 'none', color: '#fff',
+              cursor: addFeed.isPending || !url.trim() ? 'not-allowed' : 'pointer',
+              opacity: addFeed.isPending || !url.trim() ? 0.5 : 1,
+            }}
+          >
+            {addFeed.isPending ? 'Adding…' : 'Add feed'}
+          </button>
+        </div>
+        {submitErr && (
+          <p className="text-[11px]" style={{ color: 'var(--maroon)', lineHeight: 1.4 }}>{submitErr}</p>
+        )}
+      </div>
+
+      <div className="flex items-start gap-2 px-1">
         <Info size={12} style={{ color: 'var(--teal)', marginTop: 2, flexShrink: 0 }} />
         <p className="text-[10px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>
-          Calendar connection is on the roadmap. The buttons above currently surface a placeholder — track progress on{' '}
-          <a href="https://github.com/ingra107/mn-ccore-lab/issues/45" target="_blank" rel="noopener" style={{ color: 'var(--teal)', textDecoration: 'underline' }}>
-            issue #45
-          </a>.
+          The URL is the secret — anyone with it can read the calendar. Hub stores it encrypted at rest in D1
+          and never re-displays it after save (you'll see a host preview instead). Remove a feed any time below.
         </p>
       </div>
     </div>
   )
 }
 
-function IntegrationCard({ icon: Icon, name, status, description, ctaLabel, onConnect }: {
-  icon: typeof Settings; name: string; status: 'connected' | 'not_connected'; description: string; ctaLabel: string; onConnect: () => void
-}) {
-  const isConnected = status === 'connected'
+function CalendarFeedRow({ feed, onRemove }: { feed: CalendarFeed; onRemove: () => void }) {
+  const lastPolled = feed.lastPolledAt
+    ? new Date(feed.lastPolledAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+    : 'never'
   return (
     <div
       className="flex items-start gap-3 p-3 rounded-lg border"
@@ -723,35 +820,44 @@ function IntegrationCard({ icon: Icon, name, status, description, ctaLabel, onCo
         className="flex items-center justify-center w-9 h-9 rounded-md flex-shrink-0"
         style={{ background: 'var(--teal-active)' }}
       >
-        <Icon size={16} style={{ color: 'var(--teal)' }} />
+        <CalendarIcon size={16} style={{ color: 'var(--teal)' }} />
       </div>
       <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-0.5">
-          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>{name}</span>
-          <span
-            className="text-[10px] px-1.5 py-0.5 rounded"
-            style={{
-              background: isConnected ? 'var(--green-emphasis, rgba(110,232,154,0.12))' : 'rgba(255,255,255,0.06)',
-              color: isConnected ? 'var(--green)' : 'var(--slate)',
-              opacity: 0.85,
-            }}
-          >
-            {isConnected ? 'Connected' : 'Not connected'}
-          </span>
+        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>{feed.label}</span>
+          {feed.lastError ? (
+            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(240,115,126,0.12)', color: 'var(--maroon)' }}>
+              error
+            </span>
+          ) : feed.lastPolledAt ? (
+            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(110,232,154,0.12)', color: 'var(--green)' }}>
+              connected
+            </span>
+          ) : (
+            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--slate)' }}>
+              pending
+            </span>
+          )}
         </div>
-        <p className="text-[11px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>{description}</p>
+        <p className="text-[11px] truncate" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }} title={feed.urlPreview}>
+          {feed.urlPreview}
+        </p>
+        <p className="text-[10px] mt-0.5" style={{ color: 'var(--slate)', opacity: 0.6 }}>
+          {feed.lastError ? `Last error: ${feed.lastError}` : `Last poll: ${lastPolled}`}
+        </p>
       </div>
       <button
         type="button"
-        onClick={onConnect}
-        className="inline-flex items-center gap-1.5 rounded flex-shrink-0"
+        onClick={onRemove}
+        aria-label="Remove feed"
+        className="inline-flex items-center gap-1 rounded flex-shrink-0"
         style={{
-          fontSize: 11, fontWeight: 500, padding: '6px 12px',
+          fontSize: 11, fontWeight: 500, padding: '6px 10px',
           background: 'transparent', border: '1px solid var(--border-subtle)',
           color: 'var(--slate)', cursor: 'pointer',
         }}
       >
-        {ctaLabel}
+        <X size={12} /> Remove
       </button>
     </div>
   )

--- a/src/pages/portal/TodayPage.tsx
+++ b/src/pages/portal/TodayPage.tsx
@@ -11,7 +11,7 @@
 // explicit ▶ button = promote (Rule 58).
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
-import { useTasks, useProjects, useMeetingsApi, useExpiringRegulatory } from '../../hooks/useApiData'
+import { useTasks, useProjects, useMeetingsApi, useExpiringRegulatory, useUserCalendarEvents } from '../../hooks/useApiData'
 import { useAuth } from '../../hooks/useAuth'
 import { emailToSlug } from '../../lib/emailSlug'
 import { usePageMeta } from '../../hooks/usePageMeta'
@@ -24,7 +24,7 @@ import {
   ACCENT_GOLD, ACCENT_GREEN,
   INK, INK_MUTED, INK_DIM, PAGE_BG, PANEL_BG,
   todayKey, daysSince, formatTodayDate,
-  meetingToEvent, isToday, hoursSinceLastSync,
+  meetingToEvent, calendarEventToTodayEvent, isToday, hoursSinceLastSync,
   getGroupForTask,
   type GroupKey, type TodayEvent, type DailyCounts,
 } from '../../components/today/constants'
@@ -47,6 +47,7 @@ export default function TodayPage() {
   const projectsQuery = useProjects()
   const meetingsQuery = useMeetingsApi()
   const regulatoryQuery = useExpiringRegulatory(60)
+  const calendarEventsQuery = useUserCalendarEvents()
 
   const tasks: TaskRow[] = useMemo(() => (tasksQuery.data ?? []).filter((t) => t.completed === 0 && t.status !== 'done'), [tasksQuery.data])
 
@@ -159,11 +160,22 @@ export default function TodayPage() {
     })
   }, [tasksQuery.data])
 
-  // Today events.
+  // Today events. Merge team meetings (D1 `meetings` table — date-only, no
+  // time) with the user's personal iCal feed events (timed). Sort so timed
+  // events appear in chronological order and untimed meetings sink to the
+  // top as the "all day" band.
   const todaysMeetings: TodayEvent[] = useMemo(() => {
-    const all = meetingsQuery.data ?? []
-    return all.filter((m) => isToday(m.date)).map(meetingToEvent)
-  }, [meetingsQuery.data])
+    const meetings = (meetingsQuery.data ?? []).filter((m) => isToday(m.date)).map(meetingToEvent)
+    const personal = (calendarEventsQuery.data ?? [])
+      .filter((e) => isToday(e.startAt))
+      .map(calendarEventToTodayEvent)
+    // Personal events with a real time go after untimed meetings, sorted
+    // by start. Untimed events keep insertion order (D1 returns by date).
+    const timed = personal.filter((e) => e.time !== '—' && e.time !== 'all day')
+    const untimed = personal.filter((e) => e.time === '—' || e.time === 'all day')
+    timed.sort((a, b) => a.time.localeCompare(b.time))
+    return [...untimed, ...meetings, ...timed]
+  }, [meetingsQuery.data, calendarEventsQuery.data])
 
   // Right Now lookup.
   const rightNowTask = state.rightNow ? tasks.find((t) => t.id === state.rightNow) ?? null : null

--- a/vitest.config.api.ts
+++ b/vitest.config.api.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+// Node-mode tests for api/ — pure-JS code that runs in Cloudflare Workers
+// and doesn't need a DOM. The browser-mode config (vitest.config.ts) is
+// for component tests; running parser tests in browser mode works but
+// adds 30+ seconds of Playwright startup per run.
+export default defineConfig({
+  test: {
+    include: ['api/**/*.test.ts'],
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Builds on #49. Real iCal feed integration replaces the placeholder Connect buttons.

Closes #45 (real this time).

## Architecture
- **No OAuth.** User pastes private iCal URL → Hub polls every ~15min on Today page load → parses VEVENTs → renders.
- **Per-user.** Each lab member's feeds are isolated. Owner check on delete.
- **Secret protection.** Raw URL never returned through GET — only obfuscated host preview (`calendar.google.com/...`).
- **Lazy refresh.** No cron worker. `/api/integrations/calendar/events` checks `last_polled_at` and refreshes stale feeds on demand. First page load after staleness eats ~500ms-1s; subsequent loads served from D1 cache.

## Cost analysis (25 users)
- D1 writes: ~500/day (10K limit on free tier, 100K on paid)
- Workers requests: ~250/day (10M limit)
- D1 storage: ~3 MB
- **$0 incremental over the existing $5/mo Workers Paid plan.**

## Schema migration (apply before merge or before deploy)
```bash
npx wrangler d1 execute mnccore-lab --remote --file=api/schema-v52-calendar-feeds.sql
npx wrangler d1 execute mnccore-lab-test --remote --file=api/schema-v52-calendar-feeds.sql
```
Additive (CREATE TABLE IF NOT EXISTS), zero breaking change.

## Verification
- `npm run build` clean
- `npx tsc --noEmit` clean
- 8 files touched

## User flow
1. Settings → Integrations tab
2. "Get this from Google Calendar → Settings → Integrate calendar → Secret address in iCal format"
3. Paste URL, optional label, click Add feed
4. Hub eager-polls on add (events visible immediately)
5. Today timeline shows events alongside team meetings, sorted chronologically

## Known limitations (documented inline)
- RRULE expansion not supported (recurring events show master only)
- TZID handling is naive (Workers have no IANA tz DB)
Both acceptable for v1; fix when reported.