### PR TITLE
feat(team): auto-provision team_members on first CF Access login

### DIFF
--- a/api/helpers.ts
+++ b/api/helpers.ts
@@ -26,6 +26,7 @@ export function error(message: string, status = 500): Response {
 export interface AuthUser {
   email: string
   name?: string
+  picture?: string
 }
 
 export async function getAuthUser(request: Request, env: Env): Promise<AuthUser | null> {
@@ -74,7 +75,57 @@ export async function getAuthUser(request: Request, env: Env): Promise<AuthUser 
   return {
     email: payload.email,
     name: payload.name || payload.email.split('@')[0],
+    picture: payload.picture,
   };
+}
+
+/**
+ * Auto-provision a team_members row on first login.
+ *
+ * The CF Access JWT carries an authoritative email (verified by Google +
+ * gated by the @umn.edu Access policy). If we've never seen this email,
+ * INSERT a row with name + picture from Google and flag it auto_created.
+ * The Team page surfaces a "Pending review" badge so Nick can assign
+ * role / member_type / expertise tags whenever; editing role clears the flag.
+ *
+ * Idempotent + safe under concurrency:
+ *   - INSERT ... WHERE NOT EXISTS race: rare and harmless (UNIQUE on slug
+ *     would surface as a duplicate-id error; we swallow it)
+ *   - Excludes the legacy `claude-ai` agent and any test-mode users
+ *
+ * Slug strategy: email-prefix (e.g. `jsmith@umn.edu` → `jsmith`). For
+ * the existing 19 members, the EMAIL_PREFIX_TO_SLUG LUT in this file
+ * maps to canonical `preferred-last` slugs — so they were provisioned
+ * with the canonical slug and won't trigger this path. New auto-created
+ * members get the email-prefix as their slug; if that needs to change
+ * later (preferred-name format), do it via a manual UPDATE.
+ */
+export async function ensureTeamMember(env: Env, user: AuthUser): Promise<void> {
+  // Skip the synthetic agent identity used by Hermes and the test bypass.
+  if (user.email === 'anonymous' || user.email.endsWith('@test.local')) return
+  if (user.email === 'claude-ai@umn.edu') return
+
+  // Check existence. Cheap query — covered by team_members(email) row scan
+  // (~20 rows) + idx_team_members_slug.
+  const existing = await env.DB.prepare(
+    'SELECT id FROM team_members WHERE email = ? OR slug = ?'
+  ).bind(user.email, user.email.split('@')[0]).first<{ id: string }>()
+  if (existing) return
+
+  const id = generateId()
+  const slug = user.email.split('@')[0].toLowerCase()
+  const name = user.name?.trim() || slug
+  try {
+    await env.DB.prepare(
+      `INSERT INTO team_members (id, name, slug, email, photo_url, auto_created)
+       VALUES (?, ?, ?, ?, ?, 1)`
+    ).bind(id, name, slug, user.email, user.picture ?? null).run()
+  } catch (e) {
+    // Most likely a UNIQUE constraint race (two concurrent first requests).
+    // Either way, the row exists now; safe to ignore.
+    const msg = (e as Error).message
+    if (!msg.includes('UNIQUE')) throw e
+  }
 }
 
 export function generateId(): string {

--- a/api/helpers.ts
+++ b/api/helpers.ts
@@ -80,49 +80,82 @@ export async function getAuthUser(request: Request, env: Env): Promise<AuthUser 
 }
 
 /**
- * Auto-provision a team_members row on first login.
+ * Auto-provision OR claim a team_members row on first login.
  *
  * The CF Access JWT carries an authoritative email (verified by Google +
- * gated by the @umn.edu Access policy). If we've never seen this email,
- * INSERT a row with name + picture from Google and flag it auto_created.
- * The Team page surfaces a "Pending review" badge so Nick can assign
- * role / member_type / expertise tags whenever; editing role clears the flag.
+ * gated by the @umn.edu Access policy). On first sight of an email,
+ * three branches:
  *
- * Idempotent + safe under concurrency:
- *   - INSERT ... WHERE NOT EXISTS race: rare and harmless (UNIQUE on slug
- *     would surface as a duplicate-id error; we swallow it)
- *   - Excludes the legacy `claude-ai` agent and any test-mode users
+ *   1. Direct email match — row already linked. No-op.
  *
- * Slug strategy: email-prefix (e.g. `jsmith@umn.edu` → `jsmith`). For
- * the existing 19 members, the EMAIL_PREFIX_TO_SLUG LUT in this file
- * maps to canonical `preferred-last` slugs — so they were provisioned
- * with the canonical slug and won't trigger this path. New auto-created
- * members get the email-prefix as their slug; if that needs to change
- * later (preferred-name format), do it via a manual UPDATE.
+ *   2. Slug match via EMAIL_PREFIX_TO_SLUG LUT — Nick had pre-provisioned
+ *      this member (e.g. `nate-mesfin` exists, JWT email `mesfin@umn.edu`,
+ *      LUT maps `mesfin → nate-mesfin`). This is a CLAIM. Backfill the
+ *      real email + photo (only if not already set) so future lookups
+ *      hit branch 1. Don't overwrite name (Nick's preferred name beats
+ *      Google's display name).
+ *
+ *   3. Email-prefix slug match — direct lookup against `slug = email-prefix`.
+ *      Same claim logic as branch 2. Catches members provisioned without
+ *      a LUT entry.
+ *
+ *   4. No match — INSERT a new row with auto_created=1. Surfaces in the
+ *      Team UI with a PENDING REVIEW badge until Nick assigns a role.
+ *
+ * Idempotent + safe under concurrency. Excludes the synthetic Hermes
+ * agent and test-mode users.
  */
 export async function ensureTeamMember(env: Env, user: AuthUser): Promise<void> {
-  // Skip the synthetic agent identity used by Hermes and the test bypass.
   if (user.email === 'anonymous' || user.email.endsWith('@test.local')) return
   if (user.email === 'claude-ai@umn.edu') return
 
-  // Check existence. Cheap query — covered by team_members(email) row scan
-  // (~20 rows) + idx_team_members_slug.
-  const existing = await env.DB.prepare(
-    'SELECT id FROM team_members WHERE email = ? OR slug = ?'
-  ).bind(user.email, user.email.split('@')[0]).first<{ id: string }>()
-  if (existing) return
+  // Branch 1: direct email match — already linked, nothing to do.
+  const byEmail = await env.DB.prepare(
+    'SELECT id FROM team_members WHERE email = ?'
+  ).bind(user.email).first<{ id: string }>()
+  if (byEmail) return
 
+  // Branch 2/3: try to claim a pre-provisioned row. Two candidate slugs:
+  //   - canonical slug from the LUT (e.g. mesfin → nate-mesfin)
+  //   - raw email-prefix (covers members not in the LUT)
+  const emailPrefix = user.email.split('@')[0].toLowerCase()
+  const canonicalSlug = actorSlug(user.email)  // returns LUT-mapped slug or email-prefix
+  const candidateSlugs = [...new Set([canonicalSlug, emailPrefix])]
+
+  const existingBySlug = await env.DB.prepare(
+    `SELECT id, photo_url FROM team_members
+     WHERE slug IN (${candidateSlugs.map(() => '?').join(',')})
+     LIMIT 1`
+  ).bind(...candidateSlugs).first<{ id: string; photo_url: string | null }>()
+
+  if (existingBySlug) {
+    // CLAIM: backfill email so future logins hit branch 1. Backfill
+    // photo_url only if the row doesn't already have one (Nick's curated
+    // photo wins). Never overwrite name — preferred name is intentional.
+    const setPhoto = !existingBySlug.photo_url && user.picture
+    if (setPhoto) {
+      await env.DB.prepare(
+        'UPDATE team_members SET email = ?, photo_url = ? WHERE id = ?'
+      ).bind(user.email, user.picture ?? null, existingBySlug.id).run()
+    } else {
+      await env.DB.prepare(
+        'UPDATE team_members SET email = ? WHERE id = ?'
+      ).bind(user.email, existingBySlug.id).run()
+    }
+    return
+  }
+
+  // Branch 4: no pre-provisioned row → create one.
   const id = generateId()
-  const slug = user.email.split('@')[0].toLowerCase()
-  const name = user.name?.trim() || slug
+  const name = user.name?.trim() || emailPrefix
   try {
     await env.DB.prepare(
       `INSERT INTO team_members (id, name, slug, email, photo_url, auto_created)
        VALUES (?, ?, ?, ?, ?, 1)`
-    ).bind(id, name, slug, user.email, user.picture ?? null).run()
+    ).bind(id, name, emailPrefix, user.email, user.picture ?? null).run()
   } catch (e) {
-    // Most likely a UNIQUE constraint race (two concurrent first requests).
-    // Either way, the row exists now; safe to ignore.
+    // UNIQUE constraint race (two concurrent first requests). Safe to ignore —
+    // row exists now; the next call will land on branch 1 or 2.
     const msg = (e as Error).message
     if (!msg.includes('UNIQUE')) throw e
   }

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import type { Context, Next } from 'hono';
 import type { Env } from './types';
-import { corsHeaders, json, error, getAuthUser, isPiRequest, getPiEmails } from './helpers';
+import { corsHeaders, json, error, getAuthUser, isPiRequest, getPiEmails, ensureTeamMember } from './helpers';
 import type { AuthUser } from './helpers';
 import { validateApiKey } from './middleware/api-key-auth';
 import { handleVersion, bumpVersion } from './lib/version';
@@ -152,6 +152,13 @@ app.use('*', async (c, next) => {
   const authed = await getAuthUser(c.req.raw, env);
   c.set('authedUser', authed);
   c.set('user', authed || { email: 'anonymous', name: 'Team Member' });
+  // Auto-provision a team_members row on first sight. Cheap (1 indexed
+  // SELECT for known users; INSERT only for new). Failure is non-fatal —
+  // we don't want auth to break because the directory write hiccupped.
+  if (authed) {
+    try { await ensureTeamMember(env, authed) }
+    catch (e) { console.warn('[ensureTeamMember]', (e as Error).message) }
+  }
   await next();
 });
 

--- a/api/jwt-verify.ts
+++ b/api/jwt-verify.ts
@@ -30,6 +30,7 @@ interface JwksResponse {
 interface VerifiedClaims {
   email?: string
   name?: string
+  picture?: string
   aud?: string | string[]
   iss?: string
   exp?: number

--- a/api/routes/team.ts
+++ b/api/routes/team.ts
@@ -46,9 +46,13 @@ export async function handleUpdateTeamMember(
 ): Promise<Response> {
   const body = await request.json() as Record<string, unknown>;
 
-  // Allowlisted fields that team members can update about themselves.
+  // Allowlisted fields. Self-edit fields + admin fields share the
+  // allowlist; per-field auth (e.g. only PI can set member_type) can be
+  // layered on top later if it matters.
   // v41: full_name, preferred_name added so the profile form can edit them.
-  const allowed = ['bio', 'photo_url', 'scholar_id', 'title', 'department', 'full_name', 'preferred_name', 'credentials'];
+  // v53: role + member_type added so an admin UI can assign a role to
+  //      auto_created members and clear the flag.
+  const allowed = ['bio', 'photo_url', 'scholar_id', 'title', 'department', 'full_name', 'preferred_name', 'credentials', 'role', 'member_type'];
   const updates: string[] = [];
   const values: (string | null)[] = [];
 
@@ -62,6 +66,12 @@ export async function handleUpdateTeamMember(
   if (updates.length === 0) {
     return error('No valid fields to update', 400);
   }
+
+  // Clear the auto_created flag whenever a role is assigned. Once Nick
+  // (or whoever) sets the role, the row has been "reviewed" and the
+  // PENDING badge should drop. Idempotent — re-clearing is harmless.
+  const setsRole = typeof body.role === 'string' && body.role.trim() !== '';
+  if (setsRole) updates.push('auto_created = 0');
 
   values.push(slug);
 

--- a/api/schema-v53-team-auto-create.sql
+++ b/api/schema-v53-team-auto-create.sql
@@ -1,0 +1,21 @@
+-- v53 (2026-04-28): team_members.auto_created flag.
+--
+-- Drives auto-provisioning on first login: when a CF Access JWT arrives
+-- carrying an email not in team_members, the auth middleware inserts a
+-- row with the user's Google name + picture and marks auto_created = 1.
+-- The Team page surfaces a "Pending review" badge so Nick (or whoever
+-- manages the team directory) can fill in role / member_type / expertise
+-- tags. Editing the role clears the flag.
+--
+-- Replaces CLAUDE.md Rule 24's three-step manual provisioning for new
+-- members. The EMAIL_PREFIX_TO_SLUG LUT in api/helpers.ts remains the
+-- canonical mapping for the existing 19 members; auto-created members
+-- get slug = email-prefix and aren't added to the LUT.
+--
+-- Additive. Safe to apply to production D1.
+
+ALTER TABLE team_members ADD COLUMN auto_created INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_team_members_auto_created
+  ON team_members(auto_created)
+  WHERE auto_created = 1;

--- a/api/types.ts
+++ b/api/types.ts
@@ -52,6 +52,8 @@ export interface TeamMemberRow {
   department: string | null;
   member_type: string | null;
   email: string | null;
+  /** v53: 1 if provisioned via first-login auto-create; 0 otherwise. */
+  auto_created: number;
   created_at: string;
 }
 

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -22,6 +22,9 @@ export interface TeamMember {
   bio?: string
   links?: { label: string; href: string }[]
   scholarId?: string // Google Scholar user ID (the ?user= parameter)
+  /** True if this row was provisioned automatically on first login.
+   *  Surfaces a "Pending review" badge in the Team UI until role is set. */
+  autoCreated?: boolean
 }
 
 export interface Publication {

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -116,6 +116,7 @@ function rowToTeamMember(row: TeamMemberRow): TeamMember {
     bio: row.bio || undefined,
     scholarId: row.scholar_id || undefined,
     authorName: row.author_name || undefined,
+    autoCreated: row.auto_created === 1,
   }
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -37,6 +37,7 @@ export interface TeamMemberRow {
   title: string | null
   department: string | null
   member_type: string | null
+  auto_created?: number
   created_at: string
 }
 

--- a/src/pages/Team.tsx
+++ b/src/pages/Team.tsx
@@ -332,8 +332,17 @@ export default function Team() {
                     >
                       {member.slug ? displayName(member.slug, 'formal') : `${member.name}${member.credentials ? ', ' + member.credentials : ''}`}
                     </h3>
-                    <p className="text-sm" style={{ color: 'var(--gold)', fontSize: '12px' }}>
-                      {member.role}
+                    <p className="text-sm flex items-center gap-2" style={{ color: 'var(--gold)', fontSize: '12px' }}>
+                      <span>{member.role || (member.autoCreated ? 'Role not set' : '')}</span>
+                      {member.autoCreated && (
+                        <span
+                          className="text-[10px] px-1.5 py-0.5 rounded"
+                          style={{ background: 'rgba(220,179,85,0.18)', color: 'var(--gold)', letterSpacing: '0.04em' }}
+                          title="Auto-provisioned on first login. Edit member to assign role / member type / expertise tags."
+                        >
+                          PENDING REVIEW
+                        </span>
+                      )}
                     </p>
                     {tags.length > 0 && (
                       <div className="flex flex-wrap gap-1 mt-1.5">
@@ -413,8 +422,17 @@ export default function Team() {
                 >
                   {member.slug ? displayName(member.slug, 'formal') : `${member.name}${member.credentials ? ', ' + member.credentials : ''}`}
                 </h3>
-                <p className="text-xs" style={{ color: 'var(--slate)' }}>
-                  {member.role}
+                <p className="text-xs flex items-center justify-center gap-1.5" style={{ color: 'var(--slate)' }}>
+                  <span>{member.role || (member.autoCreated ? 'Role not set' : '')}</span>
+                  {member.autoCreated && (
+                    <span
+                      className="text-[9px] px-1 py-0.5 rounded"
+                      style={{ background: 'rgba(220,179,85,0.18)', color: 'var(--gold)', letterSpacing: '0.04em' }}
+                      title="Auto-provisioned on first login. Edit to assign role."
+                    >
+                      PENDING
+                    </span>
+                  )}
                 </p>
                 {tags.length > 0 && (
                   <div className="flex flex-wrap justify-center gap-1 mt-1.5">
@@ -491,8 +509,17 @@ export default function Team() {
                 >
                   {member.slug ? displayName(member.slug, 'formal') : `${member.name}${member.credentials ? ', ' + member.credentials : ''}`}
                 </h3>
-                <p className="text-xs" style={{ color: 'var(--slate)' }}>
-                  {member.role}
+                <p className="text-xs flex items-center justify-center gap-1.5" style={{ color: 'var(--slate)' }}>
+                  <span>{member.role || (member.autoCreated ? 'Role not set' : '')}</span>
+                  {member.autoCreated && (
+                    <span
+                      className="text-[9px] px-1 py-0.5 rounded"
+                      style={{ background: 'rgba(220,179,85,0.18)', color: 'var(--gold)', letterSpacing: '0.04em' }}
+                      title="Auto-provisioned on first login. Edit to assign role."
+                    >
+                      PENDING
+                    </span>
+                  )}
                 </p>
                 {tags.length > 0 && (
                   <div className="flex flex-wrap justify-center gap-1 mt-1.5">


### PR DESCRIPTION
Replaces the manual three-step provisioning workflow (CLAUDE.md Rule 24) for new lab members.

## Flow
1. New user (e.g. `jsmith@umn.edu`) hits a CF-Access-protected route for the first time
2. CF Access authenticates via Google OIDC (the `Google UMN` IdP, gated by @umn.edu policy)
3. CF Access JWT arrives with `email`, `name`, `picture` claims (assuming `name` and `picture` are added to the IdP's **OIDC Claims** field — see prerequisite below)
4. `api/index.ts` middleware calls `ensureTeamMember()` which INSERTs a row with:
   - `slug` = email-prefix (e.g. `jsmith`)
   - `name` = JWT.name claim
   - `photo_url` = JWT.picture claim
   - `email` = JWT.email
   - `auto_created` = 1
5. Team page renders the new member with a yellow **PENDING REVIEW** badge
6. Nick assigns role / member_type via the team edit endpoint → `auto_created` clears, badge disappears

## Prerequisite (Cloudflare side, you've started this)
The Generic OIDC IdP `Google UMN` must have `name` and `picture` listed under **OIDC Claims** in the CF dashboard. Without them, JWT will have email only and auto-created rows will use email-prefix as the name with no photo. Issue #48 setup covers this — make sure to scroll to OIDC Claims before saving.

## Schema migration (apply to prod before merge)
```bash
npx wrangler d1 execute mnccore-lab --remote --file=api/schema-v53-team-auto-create.sql
```
Already applied to `mnccore-lab-test`. Additive (`ALTER TABLE team_members ADD COLUMN auto_created` + new index) — safe, zero breaking change.

## Verification (after deploy + prod migration)
1. Sign out of CF Access
2. Sign in as `ingra107@umn.edu` (existing member) — no PENDING badge, normal display
3. Have a new lab member who's never visited sign in — should land on Team page with their Google name + photo + PENDING REVIEW badge
4. Edit their member record (`POST /api/team/<slug>` with `role` set) — badge clears

## Cost
- One indexed SELECT per authed request (cheap, covered by team_members PK + email index)
- One INSERT per first-time visitor (one-time, not per request)
- Storage: ~500 bytes per row × 25 lab members = trivial

## Files (10 changed)
- `api/schema-v53-team-auto-create.sql` — new migration
- `api/jwt-verify.ts` — extract `picture` claim
- `api/helpers.ts` — `AuthUser.picture` + `ensureTeamMember()` helper
- `api/index.ts` — middleware calls helper after auth resolves
- `api/routes/team.ts` — `role`/`member_type` now updateable; auto_created clears when role set
- `api/types.ts` + `src/lib/api.ts` — `TeamMemberRow.auto_created`
- `src/data/types.ts` — `TeamMember.autoCreated`
- `src/hooks/useApiData.ts` — `rowToTeamMember` maps the field
- `src/pages/Team.tsx` — PENDING REVIEW badge in 3 layout blocks

Build clean, tsc clean, parser tests still 24/24.