### PR TITLE
feat(profile): /portal/profile page + lock down team update auth

### DIFF
--- a/api/routes/team.ts
+++ b/api/routes/team.ts
@@ -1,5 +1,5 @@
 import type { AuthUser, Env } from '../helpers';
-import { json, error, logActivity } from '../helpers';
+import { json, error, logActivity, actorSlug, getPiEmails } from '../helpers';
 
 // GET /api/team
 export async function handleTeam(env: Env): Promise<Response> {
@@ -37,39 +37,67 @@ export async function handleCVData(slug: string, env: Env): Promise<Response> {
   });
 }
 
-// PUT /api/team/:slug — team member updates own profile
+// Self-edit fields — anyone can update on their own profile.
+const SELF_EDIT_FIELDS = ['bio', 'photo_url', 'scholar_id', 'title', 'department', 'full_name', 'preferred_name', 'credentials'] as const
+
+// Admin-only fields — only PI emails (lab_settings.pi_emails) can set.
+// role/member_type assignment is admin-only because it determines team
+// directory grouping + sets the gold-pill role label visible to the
+// whole lab.
+const ADMIN_ONLY_FIELDS = ['role', 'member_type'] as const
+
+const ALL_ALLOWED_FIELDS: readonly string[] = [...SELF_EDIT_FIELDS, ...ADMIN_ONLY_FIELDS]
+
+// PUT /api/team/:slug — update a team member's profile.
+// Authorization:
+//   - User editing their OWN row (slug derived from JWT email == path slug):
+//     can update SELF_EDIT_FIELDS only
+//   - User in lab_settings.pi_emails:
+//     can update any row, including ADMIN_ONLY_FIELDS
+//   - Anyone else: 403
 export async function handleUpdateTeamMember(
   slug: string,
   request: Request,
   user: AuthUser,
   env: Env,
 ): Promise<Response> {
+  // Auth boundary. Anonymous fallback identity has email='anonymous';
+  // reject before any DB write. (REQUIRE_AUTH=1 in prod also blocks at
+  // middleware level, but this is defense-in-depth.)
+  if (!user.email || user.email === 'anonymous') {
+    return error('Authentication required', 401);
+  }
+
+  const callerSlug = actorSlug(user.email);
+  const piEmails = await getPiEmails(env);
+  const isPi = piEmails.has(user.email.toLowerCase());
+  const isOwner = callerSlug === slug;
+
+  if (!isOwner && !isPi) {
+    return error('Forbidden — can only edit your own profile', 403);
+  }
+
   const body = await request.json() as Record<string, unknown>;
 
-  // Allowlisted fields. Self-edit fields + admin fields share the
-  // allowlist; per-field auth (e.g. only PI can set member_type) can be
-  // layered on top later if it matters.
-  // v41: full_name, preferred_name added so the profile form can edit them.
-  // v53: role + member_type added so an admin UI can assign a role to
-  //      auto_created members and clear the flag.
-  const allowed = ['bio', 'photo_url', 'scholar_id', 'title', 'department', 'full_name', 'preferred_name', 'credentials', 'role', 'member_type'];
   const updates: string[] = [];
   const values: (string | null)[] = [];
 
   for (const [key, val] of Object.entries(body)) {
-    if (allowed.includes(key)) {
-      updates.push(`${key} = ?`);
-      values.push(val as string | null);
+    if (!ALL_ALLOWED_FIELDS.includes(key)) continue
+    // Admin-only field guard.
+    if (ADMIN_ONLY_FIELDS.includes(key as typeof ADMIN_ONLY_FIELDS[number]) && !isPi) {
+      return error(`Field "${key}" can only be set by a PI`, 403);
     }
+    updates.push(`${key} = ?`);
+    values.push(val as string | null);
   }
 
   if (updates.length === 0) {
     return error('No valid fields to update', 400);
   }
 
-  // Clear the auto_created flag whenever a role is assigned. Once Nick
-  // (or whoever) sets the role, the row has been "reviewed" and the
-  // PENDING badge should drop. Idempotent — re-clearing is harmless.
+  // Clear the auto_created flag whenever a role is assigned (admin-only
+  // path; only PI reaches here). Idempotent — re-clearing is harmless.
   const setsRole = typeof body.role === 'string' && body.role.trim() !== '';
   if (setsRole) updates.push('auto_created = 0');
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,6 +133,7 @@ const ActivityPage = lazy(() => import('./pages/portal/ActivityPage'))
 const AnalyticsPage = lazy(() => import('./pages/portal/AnalyticsPage'))
 const InsightsPage = lazy(() => import('./pages/portal/InsightsPage'))
 const SettingsPage = lazy(() => import('./pages/portal/SettingsPage'))
+const ProfilePage = lazy(() => import('./pages/portal/ProfilePage'))
 const MeetingNotesPage = lazy(() => import('./pages/portal/MeetingNotesPage'))
 const DecisionsPage = lazy(() => import('./pages/portal/DecisionsPage'))
 const NarrativesPage = lazy(() => import('./pages/portal/NarrativesPage'))
@@ -285,6 +286,7 @@ export default function App() {
                   <Route path="/portal/pb" element={<ErrorBoundary><PBSector /></ErrorBoundary>} />
                   <Route path="/portal/sessions" element={<ErrorBoundary><SessionHistory /></ErrorBoundary>} />
                   <Route path="/portal/settings" element={<ErrorBoundary><SettingsPage /></ErrorBoundary>} />
+                  <Route path="/portal/profile" element={<ErrorBoundary><ProfilePage /></ErrorBoundary>} />
 
                   {/* Team member pages — under portal layout when navigating
                       from inside the portal. Audit caught: clicking a teammate

--- a/src/components/CalendarFeedsPanel.tsx
+++ b/src/components/CalendarFeedsPanel.tsx
@@ -1,0 +1,193 @@
+// CalendarFeedsPanel — UI for managing the user's iCal feed integrations.
+// Renders in two surfaces:
+//   - Settings → Integrations tab (admin-style overview)
+//   - Profile page (primary entry, contextual to "this is my profile")
+// Shares one TanStack Query cache key (`calendar-feeds`) so add/remove
+// in either surface updates the other instantly.
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { Calendar as CalendarIcon, Info, X } from 'lucide-react'
+
+interface CalendarFeed {
+  id: string
+  label: string
+  urlPreview: string
+  lastPolledAt: string | null
+  lastError: string | null
+  createdAt: string
+}
+
+export default function CalendarFeedsPanel() {
+  const queryClient = useQueryClient()
+  const { data: feeds = [] } = useQuery({
+    queryKey: ['calendar-feeds'],
+    queryFn: async () => {
+      const res = await fetch('/api/integrations/calendar/feeds')
+      if (!res.ok) return [] as CalendarFeed[]
+      const j = await res.json() as { feeds: CalendarFeed[] }
+      return j.feeds
+    },
+    staleTime: 30 * 1000,
+  })
+
+  const [url, setUrl] = useState('')
+  const [label, setLabel] = useState('')
+  const [submitErr, setSubmitErr] = useState<string | null>(null)
+
+  const addFeed = useMutation({
+    mutationFn: async (input: { url: string; label: string }) => {
+      const res = await fetch('/api/integrations/calendar/feeds', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(j.error ?? `HTTP ${res.status}`)
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      setUrl(''); setLabel(''); setSubmitErr(null)
+      queryClient.invalidateQueries({ queryKey: ['calendar-feeds'] })
+    },
+    onError: (e: Error) => setSubmitErr(e.message),
+  })
+
+  const removeFeed = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await fetch(`/api/integrations/calendar/feeds/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      return res.json()
+    },
+    onSettled: () => queryClient.invalidateQueries({ queryKey: ['calendar-feeds'] }),
+  })
+
+  return (
+    <div className="flex flex-col gap-4">
+      {feeds.length > 0 && (
+        <div className="flex flex-col gap-2">
+          {feeds.map((f) => (
+            <CalendarFeedRow key={f.id} feed={f} onRemove={() => removeFeed.mutate(f.id)} />
+          ))}
+        </div>
+      )}
+
+      <div
+        className="flex flex-col gap-2 p-3 rounded-lg border"
+        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+      >
+        <div className="flex items-center gap-2">
+          <CalendarIcon size={14} style={{ color: 'var(--teal)' }} />
+          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>Add a calendar feed</span>
+        </div>
+        <p className="text-[11px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>
+          Google: Settings → Integrate calendar → <em>Secret address in iCal format</em>.{' '}
+          iCloud: share calendar → <em>Public Calendar</em>.{' '}
+          Outlook: publish calendar → ICS link.{' '}
+          Read-only. Polled every ~15 min.
+        </p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            type="url"
+            placeholder="https://calendar.google.com/calendar/ical/..."
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            className="flex-1 rounded-md border px-2 py-1.5 text-xs outline-none"
+            style={{ borderColor: 'var(--border-subtle)', color: 'var(--ink)', background: 'var(--surface-0)' }}
+          />
+          <input
+            type="text"
+            placeholder="Label (optional)"
+            value={label}
+            onChange={(e) => setLabel(e.target.value)}
+            className="w-32 rounded-md border px-2 py-1.5 text-xs outline-none"
+            style={{ borderColor: 'var(--border-subtle)', color: 'var(--ink)', background: 'var(--surface-0)' }}
+          />
+          <button
+            type="button"
+            onClick={() => { if (url.trim()) addFeed.mutate({ url, label }) }}
+            disabled={addFeed.isPending || !url.trim()}
+            className="inline-flex items-center justify-center gap-1.5 rounded"
+            style={{
+              fontSize: 11, fontWeight: 500, padding: '6px 14px',
+              background: 'var(--teal)', border: 'none', color: '#fff',
+              cursor: addFeed.isPending || !url.trim() ? 'not-allowed' : 'pointer',
+              opacity: addFeed.isPending || !url.trim() ? 0.5 : 1,
+            }}
+          >
+            {addFeed.isPending ? 'Adding…' : 'Add feed'}
+          </button>
+        </div>
+        {submitErr && (
+          <p className="text-[11px]" style={{ color: 'var(--maroon)', lineHeight: 1.4 }}>{submitErr}</p>
+        )}
+      </div>
+
+      <div className="flex items-start gap-2 px-1">
+        <Info size={12} style={{ color: 'var(--teal)', marginTop: 2, flexShrink: 0 }} />
+        <p className="text-[10px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>
+          The URL is the secret — anyone with it can read the calendar. Hub stores it in D1
+          and never re-displays it after save (you'll see a host preview instead). Remove a feed any time above.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function CalendarFeedRow({ feed, onRemove }: { feed: CalendarFeed; onRemove: () => void }) {
+  const lastPolled = feed.lastPolledAt
+    ? new Date(feed.lastPolledAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
+    : 'never'
+  return (
+    <div
+      className="flex items-start gap-3 p-3 rounded-lg border"
+      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+    >
+      <div
+        className="flex items-center justify-center w-9 h-9 rounded-md flex-shrink-0"
+        style={{ background: 'var(--teal-active)' }}
+      >
+        <CalendarIcon size={16} style={{ color: 'var(--teal)' }} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
+          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>{feed.label}</span>
+          {feed.lastError ? (
+            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(240,115,126,0.12)', color: 'var(--maroon)' }}>
+              error
+            </span>
+          ) : feed.lastPolledAt ? (
+            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(110,232,154,0.12)', color: 'var(--green)' }}>
+              connected
+            </span>
+          ) : (
+            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--slate)' }}>
+              pending
+            </span>
+          )}
+        </div>
+        <p className="text-[11px] truncate" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }} title={feed.urlPreview}>
+          {feed.urlPreview}
+        </p>
+        <p className="text-[10px] mt-0.5" style={{ color: 'var(--slate)', opacity: 0.6 }}>
+          {feed.lastError ? `Last error: ${feed.lastError}` : `Last poll: ${lastPolled}`}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onRemove}
+        aria-label="Remove feed"
+        className="inline-flex items-center gap-1 rounded flex-shrink-0"
+        style={{
+          fontSize: 11, fontWeight: 500, padding: '6px 10px',
+          background: 'transparent', border: '1px solid var(--border-subtle)',
+          color: 'var(--slate)', cursor: 'pointer',
+        }}
+      >
+        <X size={12} /> Remove
+      </button>
+    </div>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -99,6 +99,7 @@ const navGroups: NavGroup[] = [
       { to: PATHS.activity, label: 'Activity', icon: Activity },
       { to: PATHS.analytics, label: 'Analytics', icon: BarChart3 },
       { to: PATHS.insights, label: 'Insights', icon: TrendingUp },
+      { to: PATHS.profile, label: 'My Profile', icon: User },
       { to: PATHS.settings, label: 'Settings', icon: Settings },
     ],
   },

--- a/src/constants/paths.ts
+++ b/src/constants/paths.ts
@@ -52,6 +52,7 @@ export const PATHS = {
   pb: `${PORTAL_PREFIX}/pb`,
   sessions: `${PORTAL_PREFIX}/sessions`,
   settings: `${PORTAL_PREFIX}/settings`,
+  profile: `${PORTAL_PREFIX}/profile`,
 
   teamMember: (slug: string) => `${PORTAL_PREFIX}/team/${slug}`,
   teamTrajectory: (slug: string) => `${PORTAL_PREFIX}/team/${slug}/trajectory`,

--- a/src/pages/portal/ProfilePage.tsx
+++ b/src/pages/portal/ProfilePage.tsx
@@ -1,0 +1,261 @@
+// Profile page — what every user sees at /portal/profile. Lets them
+// update their own team_members fields (preferred_name, full_name, title,
+// bio, photo_url, scholar_id, credentials) and manage their iCal feed
+// integrations. role + member_type are admin-only and rendered read-only here.
+
+import { useState, useEffect } from 'react'
+import { Navigate, Link } from 'react-router-dom'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { User, Save, Calendar as CalendarIcon, Settings as SettingsIcon, ExternalLink } from 'lucide-react'
+import { useAuth } from '../../hooks/useAuth'
+import { emailToSlug } from '../../lib/emailSlug'
+import { useTeam } from '../../hooks/useApiData'
+import PageHeader from '../../components/PageHeader'
+import Avatar from '../../components/Avatar'
+import { TextSkeleton } from '../../components/LoadingSkeleton'
+import CalendarFeedsPanel from '../../components/CalendarFeedsPanel'
+
+interface ProfileForm {
+  preferred_name: string
+  full_name: string
+  credentials: string
+  title: string
+  department: string
+  bio: string
+  photo_url: string
+  scholar_id: string
+}
+
+const FIELD_LABELS: Record<keyof ProfileForm, string> = {
+  preferred_name: 'Preferred name',
+  full_name: 'Full name',
+  credentials: 'Credentials (e.g. MD, PhD)',
+  title: 'Title',
+  department: 'Department',
+  bio: 'Short bio',
+  photo_url: 'Profile photo URL',
+  scholar_id: 'Google Scholar user ID',
+}
+
+export default function ProfilePage() {
+  const { user, isAuthenticated, isLoading: authLoading } = useAuth()
+  const queryClient = useQueryClient()
+  const slug = emailToSlug(user?.email)
+
+  // Read the user's row from the cached team list. useTeam runs the
+  // existing rowToTeamMember mapper which strips full_name/preferred_name
+  // (those aren't on the public TeamMember shape), so we ALSO need the
+  // raw row. Cheap second fetch since it shares the cache layer; we can
+  // promote this to a single endpoint later if it matters.
+  const teamQuery = useTeam()
+  const member = (teamQuery.data ?? []).find((m) => m.slug === slug)
+
+  // Server-side fetch to get the full row including full_name/preferred_name
+  // which the public TeamMember shape doesn't carry. This piggybacks on
+  // the same /api/team response — we just dig into it post-fetch.
+  const rawRow = (queryClient.getQueryData<{ data: Array<Record<string, unknown>> } | undefined>(['team-raw'])?.data ?? [])
+    .find((r) => r.slug === slug)
+
+  // Pull the full row directly via fetch to get preferred_name + full_name.
+  // Stored on a separate cache key so it doesn't compete with the public
+  // useTeam mapping.
+  useEffect(() => {
+    if (!slug) return
+    if (rawRow) return
+    fetch('/api/team').then((r) => r.ok ? r.json() : null).then((j) => {
+      if (j) queryClient.setQueryData(['team-raw'], j)
+    }).catch(() => { /* ignore */ })
+  }, [slug, rawRow, queryClient])
+
+  const [form, setForm] = useState<ProfileForm>({
+    preferred_name: '', full_name: '', credentials: '', title: '',
+    department: '', bio: '', photo_url: '', scholar_id: '',
+  })
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+
+  // Hydrate form when row loads.
+  useEffect(() => {
+    if (!rawRow) return
+    setForm({
+      preferred_name: (rawRow.preferred_name as string | null) ?? '',
+      full_name: (rawRow.full_name as string | null) ?? (rawRow.name as string | null) ?? '',
+      credentials: (rawRow.credentials as string | null) ?? '',
+      title: (rawRow.title as string | null) ?? '',
+      department: (rawRow.department as string | null) ?? '',
+      bio: (rawRow.bio as string | null) ?? '',
+      photo_url: (rawRow.photo_url as string | null) ?? '',
+      scholar_id: (rawRow.scholar_id as string | null) ?? '',
+    })
+  }, [rawRow])
+
+  const save = useMutation({
+    mutationFn: async (patch: Partial<ProfileForm>) => {
+      const res = await fetch(`/api/team/${slug}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({})) as { error?: string }
+        throw new Error(j.error ?? `HTTP ${res.status}`)
+      }
+      return res.json()
+    },
+    onSuccess: () => {
+      setSavedAt(Date.now())
+      queryClient.invalidateQueries({ queryKey: ['team'] })
+      queryClient.invalidateQueries({ queryKey: ['team-raw'] })
+    },
+  })
+
+  if (authLoading) return <TextSkeleton lines={6} />
+  if (!isAuthenticated) return <Navigate to="/portal/dashboard" replace />
+  if (!slug) {
+    return (
+      <div className="content-container">
+        <PageHeader icon={<User size={20} />} title="Profile" subtitle="Sign in to view your profile" />
+      </div>
+    )
+  }
+  if (teamQuery.isLoading || !rawRow) return <TextSkeleton lines={8} />
+  if (!member || !rawRow) {
+    return (
+      <div className="content-container">
+        <PageHeader icon={<User size={20} />} title="Profile" subtitle="No profile yet" />
+        <p className="text-sm" style={{ color: 'var(--muted)' }}>
+          Your team_members row hasn't been provisioned yet. Visit any portal page to trigger auto-create,
+          then return here.
+        </p>
+      </div>
+    )
+  }
+
+  const m = member
+  const showSavedHint = savedAt && (Date.now() - savedAt) < 3000
+
+  return (
+    <div className="content-container">
+      <PageHeader icon={<User size={20} />} title="My Profile" subtitle="Update your profile and connect your calendar." />
+
+      {/* Identity card — read-only avatar + name + email */}
+      <div
+        className="flex items-start gap-4 mb-6 p-4 rounded-lg border"
+        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
+      >
+        <Avatar
+          name={m.name}
+          initials={m.initials}
+          photoUrl={m.photoUrl}
+          size="lg"
+          variant="ice"
+        />
+        <div className="flex-1 min-w-0">
+          <h2 className="text-lg font-semibold" style={{ color: 'var(--ink)' }}>{m.name}</h2>
+          <p className="text-xs mt-0.5" style={{ color: 'var(--muted)' }}>{user?.email}</p>
+          <div className="flex flex-wrap items-center gap-2 mt-2">
+            {m.role && (
+              <span className="text-[11px] px-2 py-0.5 rounded" style={{ background: 'rgba(201,168,76,0.14)', color: 'var(--gold)' }}>
+                {m.role}
+              </span>
+            )}
+            {rawRow.member_type ? (
+              <span className="text-[11px] px-2 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--slate)' }}>
+                {String(rawRow.member_type)}
+              </span>
+            ) : null}
+            <Link
+              to={`/portal/team/${slug}`}
+              className="inline-flex items-center gap-1 text-[11px]"
+              style={{ color: 'var(--teal)' }}
+            >
+              View public profile <ExternalLink size={11} />
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* Editable fields */}
+      <section className="mb-6">
+        <h3 className="text-sm font-semibold mb-3" style={{ color: 'var(--ink)' }}>About you</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {(Object.keys(FIELD_LABELS) as Array<keyof ProfileForm>).map((field) => (
+            <ProfileField
+              key={field}
+              label={FIELD_LABELS[field]}
+              value={form[field]}
+              onChange={(v) => setForm((f) => ({ ...f, [field]: v }))}
+              onBlur={() => {
+                const original = (rawRow?.[field] as string | null) ?? ''
+                if (form[field] !== original) save.mutate({ [field]: form[field] })
+              }}
+              multiline={field === 'bio'}
+            />
+          ))}
+        </div>
+        {save.isError && (
+          <p className="text-[11px] mt-2" style={{ color: 'var(--maroon)' }}>
+            {(save.error as Error).message}
+          </p>
+        )}
+        {showSavedHint && (
+          <p className="text-[11px] mt-2 inline-flex items-center gap-1" style={{ color: 'var(--green)' }}>
+            <Save size={11} /> Saved
+          </p>
+        )}
+      </section>
+
+      {/* Calendar feeds */}
+      <section className="mb-6">
+        <div className="flex items-center gap-2 mb-3">
+          <CalendarIcon size={16} style={{ color: 'var(--teal)' }} />
+          <h3 className="text-sm font-semibold" style={{ color: 'var(--ink)' }}>Calendar feeds</h3>
+        </div>
+        <p className="text-[11px] mb-3" style={{ color: 'var(--muted)', lineHeight: 1.5 }}>
+          Connect your personal calendar so events appear on the Today timeline alongside team meetings.
+          Read-only — Hub never writes back to your calendar.
+        </p>
+        <CalendarFeedsPanel />
+      </section>
+
+      {/* Settings link */}
+      <section>
+        <Link
+          to="/portal/settings"
+          className="inline-flex items-center gap-2 text-xs"
+          style={{ color: 'var(--teal)' }}
+        >
+          <SettingsIcon size={14} /> Open full Settings (theme, lab thresholds, etc.)
+        </Link>
+      </section>
+    </div>
+  )
+}
+
+function ProfileField({ label, value, onChange, onBlur, multiline }: {
+  label: string; value: string; onChange: (v: string) => void; onBlur: () => void; multiline?: boolean
+}) {
+  return (
+    <div className={multiline ? 'md:col-span-2' : ''}>
+      <label className="block text-[11px] font-medium mb-1" style={{ color: 'var(--slate)' }}>{label}</label>
+      {multiline ? (
+        <textarea
+          rows={3}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onBlur}
+          className="w-full rounded-md border px-2 py-1.5 text-sm outline-none"
+          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)', color: 'var(--ink)', resize: 'vertical' }}
+        />
+      ) : (
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onBlur={onBlur}
+          className="w-full rounded-md border px-2 py-1.5 text-sm outline-none"
+          style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-0)', color: 'var(--ink)' }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/pages/portal/SettingsPage.tsx
+++ b/src/pages/portal/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import {
   Settings, Type, Layers, Plus, X, GripVertical, Check, Bot, Info, Palette, RotateCcw, Sun, Moon, Users, ArrowRight,
-  FlaskConical, Microscope, Brain, Heart, Activity, Stethoscope, Dna, Atom, BookOpen, Beaker, Calendar as CalendarIcon, Link2,
+  FlaskConical, Microscope, Brain, Heart, Activity, Stethoscope, Dna, Atom, BookOpen, Beaker, Link2,
 } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
 import EmptyState from '../../components/EmptyState'
@@ -16,6 +16,7 @@ import InlineSelect from '../../components/InlineSelect'
 import { getPersonInfo } from '../../data/team'
 import { useLabPrefs } from '../../hooks/useLabPrefs'
 import RangeSlider from '../../components/RangeSlider'
+import CalendarFeedsPanel from '../../components/CalendarFeedsPanel'
 
 interface WorkflowTemplate {
   id: string
@@ -674,194 +675,12 @@ function LabPrefsPanel() {
   )
 }
 
-interface CalendarFeed {
-  id: string
-  label: string
-  urlPreview: string
-  lastPolledAt: string | null
-  lastError: string | null
-  createdAt: string
-}
-
+// Settings → Integrations tab thin wrapper. The real UI lives in
+// src/components/CalendarFeedsPanel so it can also embed in the Profile page.
 function IntegrationsPanel() {
-  // Personal iCal feed integration (issue #45). Each user pastes the
-  // private iCal URL from their calendar provider (Google: Settings →
-  // Integrate calendar → "Secret address in iCal format"; iCloud: share
-  // → "Public Calendar"; Outlook: publish a calendar). Hub polls the URL
-  // lazily on Today page load (>15min stale = refresh) and renders events
-  // alongside team meetings. URL stays in D1, never re-rendered after save.
-  const queryClient = useQueryClient()
-  const { data: feeds = [] } = useQuery({
-    queryKey: ['calendar-feeds'],
-    queryFn: async () => {
-      const res = await fetch('/api/integrations/calendar/feeds')
-      if (!res.ok) return [] as CalendarFeed[]
-      const j = await res.json() as { feeds: CalendarFeed[] }
-      return j.feeds
-    },
-    staleTime: 30 * 1000,
-  })
-
-  const [url, setUrl] = useState('')
-  const [label, setLabel] = useState('')
-  const [submitErr, setSubmitErr] = useState<string | null>(null)
-
-  const addFeed = useMutation({
-    mutationFn: async (input: { url: string; label: string }) => {
-      const res = await fetch('/api/integrations/calendar/feeds', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input),
-      })
-      if (!res.ok) {
-        const j = await res.json().catch(() => ({})) as { error?: string }
-        throw new Error(j.error ?? `HTTP ${res.status}`)
-      }
-      return res.json()
-    },
-    onSuccess: () => {
-      setUrl(''); setLabel(''); setSubmitErr(null)
-      queryClient.invalidateQueries({ queryKey: ['calendar-feeds'] })
-    },
-    onError: (e: Error) => setSubmitErr(e.message),
-  })
-
-  const removeFeed = useMutation({
-    mutationFn: async (id: string) => {
-      const res = await fetch(`/api/integrations/calendar/feeds/${id}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error(`HTTP ${res.status}`)
-      return res.json()
-    },
-    onSettled: () => queryClient.invalidateQueries({ queryKey: ['calendar-feeds'] }),
-  })
-
-  return (
-    <div className="flex flex-col gap-4">
-      {feeds.length > 0 && (
-        <div className="flex flex-col gap-2">
-          {feeds.map((f) => (
-            <CalendarFeedRow key={f.id} feed={f} onRemove={() => removeFeed.mutate(f.id)} />
-          ))}
-        </div>
-      )}
-
-      <div
-        className="flex flex-col gap-2 p-3 rounded-lg border"
-        style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-      >
-        <div className="flex items-center gap-2">
-          <CalendarIcon size={14} style={{ color: 'var(--teal)' }} />
-          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>Add a calendar feed</span>
-        </div>
-        <p className="text-[11px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>
-          Google: Settings → Integrate calendar → <em>Secret address in iCal format</em>.{' '}
-          iCloud: share calendar → <em>Public Calendar</em>.{' '}
-          Outlook: publish calendar → ICS link.{' '}
-          Read-only. Polled every ~15 min.
-        </p>
-        <div className="flex flex-col gap-2 sm:flex-row">
-          <input
-            type="url"
-            placeholder="https://calendar.google.com/calendar/ical/..."
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            className="flex-1 rounded-md border px-2 py-1.5 text-xs outline-none"
-            style={{ borderColor: 'var(--border-subtle)', color: 'var(--ink)', background: 'var(--surface-0)' }}
-          />
-          <input
-            type="text"
-            placeholder="Label (optional)"
-            value={label}
-            onChange={(e) => setLabel(e.target.value)}
-            className="w-32 rounded-md border px-2 py-1.5 text-xs outline-none"
-            style={{ borderColor: 'var(--border-subtle)', color: 'var(--ink)', background: 'var(--surface-0)' }}
-          />
-          <button
-            type="button"
-            onClick={() => { if (url.trim()) addFeed.mutate({ url, label }) }}
-            disabled={addFeed.isPending || !url.trim()}
-            className="inline-flex items-center justify-center gap-1.5 rounded"
-            style={{
-              fontSize: 11, fontWeight: 500, padding: '6px 14px',
-              background: 'var(--teal)', border: 'none', color: '#fff',
-              cursor: addFeed.isPending || !url.trim() ? 'not-allowed' : 'pointer',
-              opacity: addFeed.isPending || !url.trim() ? 0.5 : 1,
-            }}
-          >
-            {addFeed.isPending ? 'Adding…' : 'Add feed'}
-          </button>
-        </div>
-        {submitErr && (
-          <p className="text-[11px]" style={{ color: 'var(--maroon)', lineHeight: 1.4 }}>{submitErr}</p>
-        )}
-      </div>
-
-      <div className="flex items-start gap-2 px-1">
-        <Info size={12} style={{ color: 'var(--teal)', marginTop: 2, flexShrink: 0 }} />
-        <p className="text-[10px]" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }}>
-          The URL is the secret — anyone with it can read the calendar. Hub stores it encrypted at rest in D1
-          and never re-displays it after save (you'll see a host preview instead). Remove a feed any time below.
-        </p>
-      </div>
-    </div>
-  )
+  return <CalendarFeedsPanel />
 }
 
-function CalendarFeedRow({ feed, onRemove }: { feed: CalendarFeed; onRemove: () => void }) {
-  const lastPolled = feed.lastPolledAt
-    ? new Date(feed.lastPolledAt).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })
-    : 'never'
-  return (
-    <div
-      className="flex items-start gap-3 p-3 rounded-lg border"
-      style={{ borderColor: 'var(--border-subtle)', background: 'var(--surface-1)' }}
-    >
-      <div
-        className="flex items-center justify-center w-9 h-9 rounded-md flex-shrink-0"
-        style={{ background: 'var(--teal-active)' }}
-      >
-        <CalendarIcon size={16} style={{ color: 'var(--teal)' }} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <div className="flex items-center gap-2 mb-0.5 flex-wrap">
-          <span className="text-sm font-medium" style={{ color: 'var(--ink)' }}>{feed.label}</span>
-          {feed.lastError ? (
-            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(240,115,126,0.12)', color: 'var(--maroon)' }}>
-              error
-            </span>
-          ) : feed.lastPolledAt ? (
-            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(110,232,154,0.12)', color: 'var(--green)' }}>
-              connected
-            </span>
-          ) : (
-            <span className="text-[10px] px-1.5 py-0.5 rounded" style={{ background: 'rgba(255,255,255,0.06)', color: 'var(--slate)' }}>
-              pending
-            </span>
-          )}
-        </div>
-        <p className="text-[11px] truncate" style={{ color: 'var(--slate)', opacity: 0.75, lineHeight: 1.5 }} title={feed.urlPreview}>
-          {feed.urlPreview}
-        </p>
-        <p className="text-[10px] mt-0.5" style={{ color: 'var(--slate)', opacity: 0.6 }}>
-          {feed.lastError ? `Last error: ${feed.lastError}` : `Last poll: ${lastPolled}`}
-        </p>
-      </div>
-      <button
-        type="button"
-        onClick={onRemove}
-        aria-label="Remove feed"
-        className="inline-flex items-center gap-1 rounded flex-shrink-0"
-        style={{
-          fontSize: 11, fontWeight: 500, padding: '6px 10px',
-          background: 'transparent', border: '1px solid var(--border-subtle)',
-          color: 'var(--slate)', cursor: 'pointer',
-        }}
-      >
-        <X size={12} /> Remove
-      </button>
-    </div>
-  )
-}
 
 function SettingsField({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (


### PR DESCRIPTION
Three coupled changes:

## 1. Security fix on `PUT /api/team/:slug`
**Before:** any authed user could edit any team_member row, including `role` and `member_type`.

**After:**
- **Self-edit** (`bio`, `photo_url`, `scholar_id`, `title`, `department`, `full_name`, `preferred_name`, `credentials`): only the row owner can update (matched via `actorSlug(JWT.email) === path slug`)
- **Admin-only** (`role`, `member_type`): only PI emails (from `lab_settings.pi_emails`) can update
- Anyone else: 403

This is a real auth gap fix. No team member should be able to relabel another's role from a curl one-liner.

## 2. `/portal/profile` page
Replaces the absence of any self-service profile editor. Editable fields with inline-on-blur save:
- preferred_name, full_name, credentials, title, department, bio, photo_url, scholar_id

Plus:
- Avatar + read-only role/member_type pills (admin-assigned)
- Embedded calendar feeds panel (add/remove iCal subscriptions)
- Link to public team profile + full Settings

When Nate Mesfin signs in for the first time → claims his existing `nate-mesfin` row (PR #51 logic) → can immediately edit his own profile + connect his Google Calendar without you doing anything.

## 3. `CalendarFeedsPanel` extraction
The iCal feed UI was inline in `SettingsPage`. Moved to `src/components/CalendarFeedsPanel.tsx` so it renders in both Settings → Integrations AND Profile. Shared TanStack cache key (`calendar-feeds`) means add/remove on either surface updates the other instantly.

## Sidebar
'My Profile' nav item added — uses lucide `User` icon (same as 'My Hub' which goes to my-items workspace; `User` is fine for both).

## Schema migration
None needed. v53 already covers this.

## Verification
- `npm run build` clean
- `npx tsc --noEmit` clean
- 24/24 parser tests still pass

After merge: deploy → visit /portal/profile → edit something → confirm save indicator → refresh → confirm persistence.