### PR TITLE
fix(pages): forward ExecutionContext from Pages Function to Hono

### DIFF
--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -14,5 +14,8 @@ interface Env {
 }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
-  return handler.fetch(context.request, context.env as any)
+  // Forward the ExecutionContext so Hono handlers can use `c.executionCtx.waitUntil`
+  // for fire-and-forget background work (e.g. the eager iCal feed poll on add).
+  // Without this third arg, Hono throws "This context has no ExecutionContext".
+  return handler.fetch(context.request, context.env as any, context as ExecutionContext)
 }


### PR DESCRIPTION
Fixes the 'This context has no ExecutionContext' error on POST /api/integrations/calendar/feeds (and any other route using waitUntil).

The /api/* Pages Function proxy was passing (request, env) only — missing the third arg. Hono's c.executionCtx getter throws when not initialized.

One-line proxy fix: pass `context as ExecutionContext` as third arg.