### PR TITLE
Bundle D: Brand + token sweep (8 findings)

### DIFF
--- a/audit/2026-04-28/progress-log.md
+++ b/audit/2026-04-28/progress-log.md
@@ -116,6 +116,61 @@ After Nick answers the decision queue:
 - `a5868d7c` — fix(meeting-prep): emailToSlug instead of split('@')[0] (MTG-05)
 - `2fe26a4c` — fix(manuscripts): stopPropagation on Status + Stage cells (M-01)
 
+## 2026-04-28 (Bundle B) — Lab Overview lies wired to real APIs (3 of 4)
+
+**Phase**: Fix. Bundle B = Lab Overview cards LO-2 / LO-3 / LO-4. LO-1
+(citations) explicitly blocked on Bundle G — not touched here.
+
+**Branch**: `worktree-agent-a45ff95d207b05eb0` (worktree, not pushed —
+Nick to merge manually).
+
+### LO-2 — UpcomingCard deadlines hardcoded (P0)
+
+- **File:line confirmed**: yes — `src/components/dashboard/UpcomingCard.tsx:17-53` matched `generateDeadlines()` with the cited 5 fake R01/K23/CCI items.
+- **git log since audit**: none touching the file since 2026-04-28 verification sweep.
+- **Reproduction**: read source — literal hardcoded array still rendering.
+- **Status**: STILL BROKEN → FIXED.
+- **Action**: Replaced `generateDeadlines()` with `useTasks()` (open tasks with `due_date`) + `useGrantTimeline()` (milestones via `target_date` + grant submission targets via `end_date`). Cap to 5 most-urgent: overdue first (most-overdue first), then ascending by days-until-due. Added empty state.
+- **Hook discovery**: `useDeadlines()` does NOT exist as a standalone hook. The Deadlines page derives its DeadlineItem list from `useTasks()` + `useGrantTimeline()` directly. Used the same pattern.
+- **Commit**: `ee5c6b37`.
+
+### LO-3 — GrantTimelineCard discards real data (P0)
+
+- **File:line confirmed**: yes — `src/components/dashboard/GrantTimelineCard.tsx:7-13` had hardcoded `grantTimelines` array; line 30 fetched `useGrants()` only for subtitle counts; line 39 iterated the hardcoded array.
+- **git log since audit**: none.
+- **Reproduction**: read source — hardcoded array still rendered.
+- **Status**: STILL BROKEN → FIXED.
+- **Action**: Switched from `useGrants()` to `useGrantTimeline()` because the former's `rowToGrant()` mapper discards `start_date`/`end_date` (the very fields needed). Bars now derive from real start_date/end_date (year extracted via regex). Filtered to `startYear <= CURRENT_YEAR + 5` (no speculation past 5 years per spec). Sorted by start year ASC. min/max year computed dynamically. Funded → solid; in_preparation/submitted/planning OR proposed=1 → dashed. Empty state added.
+- **Data shape surprise**: `useGrants()` returns a `Grant` type with NO date fields — `rowToGrant()` strips `start_date`/`end_date` from the API row. `useGrantTimeline()` (separate `/api/grants/timeline` endpoint) returns the full row including dates and milestones. Used the timeline hook so dates are preserved.
+- **Hook discovery**: `useGrantTimeline()` already existed in `src/hooks/useGrantTimeline.ts` — no new hook needed.
+- **Commit**: `d5ab1f25`.
+
+### LO-4 — ActivityFeedCard hardcoded marketing copy (P0)
+
+- **File:line confirmed**: yes — `src/components/dashboard/ActivityFeedCard.tsx:80-87` had the literal `'CLIF Consortium expanding to 13+ sites nationwide'` push.
+- **git log since audit**: none.
+- **Reproduction**: read source — hardcoded marketing block still pushed onto every render.
+- **Status**: STILL BROKEN → FIXED.
+- **Action**: Replaced the entire body (hardcoded marketing + synthetic publications/projects/in-review summary) with `useActivity(20)`, filtered via `isProductionVisibleActivity` to skip `_TEST_DELETE_*` + `test_delete_*` fixtures, sliced to 5. Each row: type-coded dot, actor name (resolved via `getPersonInfo(activity.actor)`), description text, relative timestamp via `formatRelativeTime`. Empty state added. "View all" footer link routed to `PATHS.activity` (was hardcoded `/publications`).
+- **Hook discovery**: `useActivity()` already existed in `src/hooks/useApiData.ts:271` — no new hook needed.
+- **Commit**: `7119d183`.
+
+### Build status
+
+`npm run build` clean after each commit. TypeScript clean (`tsc --noEmit -p tsconfig.app.json`).
+
+### Skipped findings
+
+- **LO-1 (StatsCard.totalCitations = 2626)**: explicitly NOT TOUCHED. Blocked on Bundle G (`/api/citations` endpoint per D2-followup → per-author Google Scholar via `scholarly` Python library). Will ship with Bundle G.
+
+### Notes
+
+- All 3 cards now consume real data; no fixtures/marketing copy reach the team-facing Lab Overview surface (modulo LO-1 which is correctly deferred).
+- No new hooks were created — every needed hook already existed in `src/hooks/useApiData.ts` or `src/hooks/useGrantTimeline.ts`. The brief's "if `useActivityLog` doesn't exist, create it" path was unnecessary; the existing `useActivity()` is the canonical hook.
+- LO-2 spec mentioned filtering past-date items, but the verbatim instruction also said "overdue first (negative days), then ascending by days-until-due" — kept overdue items in the list per the explicit sort spec, since "what's overdue" is exactly what the user needs to see on Lab Overview.
+- Branch merged via PR #57. Per CLAUDE.md Rule 9 "NEVER deploy from a worktree" — the worktree branch was rebased onto main + pushed, then merged via gh pr merge.
+
+---
 
 ## 2026-04-28 (later) — Decision queue walked, all 31 decisions resolved
 

--- a/src/pages/MyItems.tsx
+++ b/src/pages/MyItems.tsx
@@ -90,7 +90,7 @@ function StatCard({
           width: 40,
           height: 40,
           borderRadius: 'var(--radius-xl)',
-          background: `${accentColor}18`,
+          background: `color-mix(in srgb, ${accentColor} 9%, transparent)`,
           display: 'flex',
           alignItems: 'center',
           justifyContent: 'center',
@@ -769,19 +769,19 @@ export default function MyItems() {
             count={pending.length}
             label="Pending Action Items"
             icon={<Circle size={20} />}
-            accentColor="#c9a84c"
+            accentColor="var(--gold)"
           />
           <StatCard
             count={unreadCount}
             label="Unread Notifications"
             icon={<BellDot size={20} />}
-            accentColor="#2d8a8a"
+            accentColor="var(--teal)"
           />
           <StatCard
             count={openCommitments.length}
             label="Open Commitments"
             icon={<Handshake size={20} />}
-            accentColor="#c9a84c"
+            accentColor="var(--maroon)"
           />
         </div>
 

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -35,6 +35,7 @@ import { formatShortDate, formatMediumDate } from '../lib/dateUtils'
 import Avatar from '../components/Avatar'
 import InlineSelect from '../components/InlineSelect'
 import InlineAssigneePicker from '../components/InlineAssigneePicker'
+import CategoryIcon from '../components/CategoryIcon'
 import WatchButton from '../components/WatchButton'
 import TaskCard from '../components/tasks/TaskCard'
 import CreateTaskModal from '../components/tasks/CreateTaskModal'
@@ -455,16 +456,19 @@ function ProjectDetailInner({ project }: InnerProps) {
 
         {/* Meta row: category, PI, status, stage, agenda button — all inline-editable */}
         <div className="flex flex-wrap items-center gap-3">
-          <InlineSelect
-            value={project.category || 'lab'}
-            options={[
-              { value: 'clif', label: 'CLIF' },
-              { value: 'lab', label: 'Lab' },
-              { value: 'nate', label: 'Mesfin' },
-              { value: 'mentee', label: 'Mentee' },
-            ]}
-            onChange={(val) => d1Update.mutate({ category: val } as Partial<Project>)}
-          />
+          <div className="flex items-center gap-1.5">
+            <CategoryIcon category={project.category || 'lab'} size={14} />
+            <InlineSelect
+              value={project.category || 'lab'}
+              options={[
+                { value: 'clif', label: 'CLIF' },
+                { value: 'lab', label: 'Lab' },
+                { value: 'nate', label: 'Mesfin' },
+                { value: 'mentee', label: 'Mentee' },
+              ]}
+              onChange={(val) => d1Update.mutate({ category: val } as Partial<Project>)}
+            />
+          </div>
 
           <InlineAssigneePicker
             value={project.pi || ''}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -495,7 +495,7 @@ function ProjectDetailInner({ project }: InnerProps) {
               className="inline-flex items-center gap-1 px-2 py-1 rounded text-[11px]"
               style={{
                 background: showAgendaForm ? 'var(--gold)' : 'var(--gold-active)',
-                color: showAgendaForm ? '#0f1923' : 'var(--gold)',
+                color: showAgendaForm ? '#0f1923' : 'var(--gold-on-emphasis)',
                 border: '1px solid rgba(201,168,76,0.2)',
                 fontWeight: 500,
                 cursor: 'pointer',

--- a/src/pages/portal/AskTheLab.tsx
+++ b/src/pages/portal/AskTheLab.tsx
@@ -341,7 +341,7 @@ function QuestionExpanded({ questionId }: { questionId: string }) {
                 }}
               >
                 <div style={{ width: 24, height: 24, flexShrink: 0, paddingTop: 2 }}>
-                  <Avatar name={answerPerson.name} initials={answerPerson.initials} photoUrl={answerPerson.photoUrl} size="tight" variant="gold" />
+                  <Avatar name={answerPerson.name} initials={answerPerson.initials} photoUrl={answerPerson.photoUrl} size="tight" variant="ice" />
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-2 mb-1">

--- a/src/pages/portal/AskTheLab.tsx
+++ b/src/pages/portal/AskTheLab.tsx
@@ -204,7 +204,7 @@ function QuestionCard({
             {question.project_slug && (
               <span
                 className="text-[10px] px-1.5 py-0.5 rounded-full"
-                style={{ color: 'var(--gold)', backgroundColor: 'var(--gold-hover)' }}
+                style={{ color: 'var(--gold-on-emphasis)', backgroundColor: 'var(--gold-emphasis)' }}
               >
                 {question.project_slug}
               </span>
@@ -319,7 +319,7 @@ function QuestionExpanded({ questionId }: { questionId: string }) {
                 >
                   <div className="flex items-center gap-1.5 mb-1">
                     <HermesMark size={14} variant="avatar" />
-                    <span style={{ fontSize: '10px', color: 'var(--gold)', fontWeight: 500 }}>
+                    <span style={{ fontSize: '10px', color: 'var(--gold-on-emphasis)', fontWeight: 500 }}>
                       Hermes
                     </span>
                     <span className="ml-auto" style={{ fontSize: '10px', color: 'var(--slate)', opacity: 0.75 }}>

--- a/src/pages/portal/AskTheLab.tsx
+++ b/src/pages/portal/AskTheLab.tsx
@@ -287,8 +287,8 @@ function QuestionExpanded({ questionId }: { questionId: string }) {
     <div className="px-5 pb-5 border-t" style={{ borderColor: 'var(--border-subtle)' }}>
       {/* Full context */}
       {detail.context && (
-        <div className="mt-4 px-3 py-2.5 rounded-lg" style={{ backgroundColor: 'var(--gold-hover)', border: '1px solid rgba(201,168,76,0.1)' }}>
-          <p className="text-[11px] mb-1" style={{ color: 'var(--gold)', fontWeight: 500 }}>
+        <div className="mt-4 px-3 py-2.5 rounded-lg" style={{ backgroundColor: 'var(--surface-1)', border: '1px solid var(--border-subtle)' }}>
+          <p className="text-[11px] mb-1" style={{ color: 'var(--muted)', fontWeight: 500 }}>
             Context
           </p>
           <p className="text-sm leading-relaxed" style={{ color: 'var(--ink)', fontStyle: 'italic' }}>

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom'
 import { TrendingUp, Activity, AlertTriangle, FlaskConical } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
 import EmptyState from '../../components/EmptyState'
+import EmptyStateArt from '../../components/EmptyStateArt'
 import { TextSkeleton } from '../../components/LoadingSkeleton'
 import { TableContainer } from '../../components/table'
 import { useToast } from '../../hooks/useToast'
@@ -434,7 +435,7 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
   if (rows.length === 0) {
     return (
       <EmptyState
-        icon={<TrendingUp size={32} />}
+        icon={<EmptyStateArt variant="tasks" title="All caught up" />}
         title="No stalled projects"
         subtitle="Every active project has had a project_update within the last 14 days."
       />

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -11,6 +11,7 @@ import { useCreateProject } from '../../hooks/useMutations'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { updateProject } from '../../lib/api'
 import InlineSelect from '../../components/InlineSelect'
+import CategoryIcon from '../../components/CategoryIcon'
 import { useUndoToast } from '../../components/UndoToast'
 import { useListKeyboardNav } from '../../hooks/useListKeyboardNav'
 import { getPersonInfo } from '../../data/team'
@@ -350,15 +351,7 @@ export default function Manuscripts() {
                 }}
               >
                 {opt.value && (
-                  <span
-                    style={{
-                      width: 6,
-                      height: 6,
-                      borderRadius: 'var(--radius-circle)',
-                      background: CATEGORY_DOT[opt.value] ?? 'var(--slate)',
-                      opacity: 0.85,
-                    }}
-                  />
+                  <CategoryIcon category={opt.value} size={12} />
                 )}
                 {opt.label}
               </button>
@@ -456,12 +449,10 @@ export default function Manuscripts() {
                           }}
                         >
                           <div className="flex items-center gap-2.5" style={{ paddingRight: '16px' }}>
-                            <span
-                              style={{
-                                width: 6, height: 6, borderRadius: 'var(--radius-circle)',
-                                background: CATEGORY_DOT[project.category] ?? 'var(--slate)',
-                                flexShrink: 0, opacity: 0.85, marginTop: '-1px',
-                              }}
+                            <CategoryIcon
+                              category={project.category}
+                              size={14}
+                              style={{ flexShrink: 0 }}
                             />
                             <span style={{ fontSize: '14px', fontWeight: 500, color: 'var(--ink)', lineHeight: 1.35 }}>
                               {project.title}
@@ -568,14 +559,12 @@ export default function Manuscripts() {
                             transition: 'background 0.12s ease-out',
                           }}
                         >
-                          {/* Title row: category dot + title + task count */}
+                          {/* Title row: category icon + title + task count */}
                           <div className="flex items-start gap-2" style={{ marginBottom: '8px' }}>
-                            <span
-                              style={{
-                                width: 6, height: 6, borderRadius: 'var(--radius-circle)',
-                                background: CATEGORY_DOT[project.category] ?? 'var(--slate)',
-                                flexShrink: 0, opacity: 0.85, marginTop: '6px',
-                              }}
+                            <CategoryIcon
+                              category={project.category}
+                              size={14}
+                              style={{ flexShrink: 0, marginTop: '2px' }}
                             />
                             <span style={{ fontSize: '14px', fontWeight: 500, color: 'var(--ink)', lineHeight: 1.35, flex: 1 }}>
                               {project.title}
@@ -712,7 +701,6 @@ export default function Manuscripts() {
                     <AnimatePresence mode="popLayout">
                       {stageProjects.map((p) => {
                         const pi = getPersonInfo(p.pi)
-                        const dotColor = CATEGORY_DOT[p.category] ?? 'var(--slate)'
                         return (
                           <Link key={p.slug} to={PATHS.project(p.slug)} style={{ textDecoration: 'none', display: 'block' }}>
                             <motion.div
@@ -730,7 +718,7 @@ export default function Manuscripts() {
                               }}
                             >
                               <div className="flex items-start gap-2">
-                                <span style={{ width: 6, height: 6, borderRadius: 'var(--radius-circle)', background: dotColor, flexShrink: 0, opacity: 0.85, marginTop: '5px' }} />
+                                <CategoryIcon category={p.category} size={12} style={{ flexShrink: 0, marginTop: '2px' }} />
                                 <p style={{ fontSize: '13px', fontWeight: 600, color: 'var(--ink)', lineHeight: 1.4, margin: 0 }}>
                                   {p.title}
                                 </p>


### PR DESCRIPTION
Wave 1 of audit/2026-04-28 fix phase. 8 brand-primitive + token-discipline fixes per Rule 29 + Rule 42. Build clean. Rebased onto main to drop duplicate audit commit.

## Findings closed

- **ATL-09** — AskTheLab human-answer Avatar `variant="gold"` → `"ice"` (Rule 59: gold = AI accent).
- **ATL-11** — AskTheLab asker context panel: gold-hover bg → `--surface-1`, gold label → `--muted`. No more conflation with Hermes.
- **ATL-07** — AskTheLab project pill + Hermes pill: gold-on-gold-hover → `--gold-on-emphasis` on `--gold-emphasis` per Rule 42 (AA pass).
- **PD-9** — ProjectDetail agenda pill non-active: gold → `--gold-on-emphasis` per Rule 42.
- **PD-8** — ProjectDetail header: `<CategoryIcon>` prepended to category InlineSelect (Rule 29).
- **M-15** — Manuscripts: 4 sites of bespoke `<span>` category dots → `<CategoryIcon>` (chip row, desktop+mobile title cells, pipeline card).
- **INS-07** — InsightsPage Stalled empty state: `<TrendingUp>` lucide → `<EmptyStateArt variant="tasks">`. **First consumer of EmptyStateArt** — primitive shipped Phase 36d but had zero callers.
- **MI-08** — MyItems StatCards: 3 hex `accentColor` literals → `var(--gold)` / `var(--teal)` / `var(--maroon)` (rotated to break gold-on-gold collision). StatCard bg refactored from `${color}18` alpha trick → `color-mix(in srgb, ...)` so prop accepts CSS vars.

## Drift surfaced
- EmptyStateArt had 0 callers — wider sweep candidate
- EmptyStateArt missing `all-clear` variant (used `tasks` as best-fit semantic)
- Brief had token-type error: `--ink-label` is opacity not color; agent used `--muted` instead
- Manuscripts CATEGORY_DOT map still used at line 65 for InlineSelect dropdown dots — out of M-15 scope

## Verification
- `npm run build` clean (TypeScript + Vite) at every commit.
- All 8 findings verified STILL BROKEN against current source.
- See `audit/2026-04-28/progress-log.md` for per-finding evidence.