### PR TITLE
Bundle B: Lab Overview wires (3 of 4 fake-data cards)

### DIFF
--- a/src/components/dashboard/ActivityFeedCard.tsx
+++ b/src/components/dashboard/ActivityFeedCard.tsx
@@ -1,92 +1,59 @@
 import { memo, useMemo } from 'react'
 import { Link } from 'react-router-dom'
-import { Activity, BookOpen, FlaskConical, Users, ArrowRight } from 'lucide-react'
+import { Activity, ArrowRight } from 'lucide-react'
 import BentoCard from './BentoCard'
-import { usePublications, useProjects } from '../../hooks/useApiData'
+import { useActivity } from '../../hooks/useApiData'
 import { useDashboardMounted } from '../../pages/Dashboard'
-import { isProjectActive } from '../../lib/taskConstants'
-import type { LucideIcon } from 'lucide-react'
+import { isProductionVisibleActivity } from '../../lib/isProductionVisible'
+import { getPersonInfo } from '../../data/team'
+import { formatRelativeTime } from '../../lib/dateUtils'
+import { PATHS } from '../../constants/paths'
 
 interface FeedItem {
-  icon: LucideIcon
+  id: string
   dotColor: string
-  text: string
-  detail: string
+  actorName: string | null
+  description: string
   time: string
   link?: string
 }
 
-function relativeTime(monthsAgo: number): string {
-  if (monthsAgo <= 0) return 'This month'
-  if (monthsAgo === 1) return '1 month ago'
-  if (monthsAgo < 12) return `${monthsAgo} months ago`
-  const years = Math.floor(monthsAgo / 12)
-  return years === 1 ? '1 year ago' : `${years} years ago`
+/**
+ * Pick a small accent dot color based on the activity entry's `type`.
+ * Keeps the feed visually scannable without inventing a per-row icon.
+ */
+function dotColorForType(type: string): string {
+  if (type.startsWith('task')) return '#c9a84c'   // gold — user-driven action
+  if (type.startsWith('project')) return '#2d8a8a' // teal — system / project work
+  if (type.startsWith('comment')) return '#5cbcb4'
+  if (type.startsWith('meeting')) return '#5cbcb4'
+  if (type.startsWith('idea')) return '#c9a84c'
+  if (type.startsWith('decision')) return '#7a0019' // maroon — decision
+  return 'var(--slate)'
 }
 
 function ActivityFeedCard() {
   const mounted = useDashboardMounted()
-  const { data: publications = [] } = usePublications(undefined, { enabled: mounted })
-  const { data: projects = [] } = useProjects(undefined, { enabled: mounted })
+  // Over-fetch a bit so the post-filter feed still has 5 items.
+  const { data: rawActivity = [] } = useActivity(20)
 
   const items = useMemo<FeedItem[]>(() => {
-    const now = new Date()
-    const currentYear = now.getFullYear()
-    const currentMonth = now.getMonth()
-    const feed: FeedItem[] = []
-
-    // Recent publications (by year — treat as mid-year)
-    const recentPubs = publications
-      .filter((p) => p.status === 'Published')
-      .sort((a, b) => b.year - a.year)
-      .slice(0, 4)
-
-    recentPubs.forEach((pub) => {
-      const monthsAgo = (currentYear - pub.year) * 12 + currentMonth - 6
-      feed.push({
-        icon: BookOpen,
-        dotColor: '#c9a84c',
-        text: pub.title.length > 70 ? pub.title.slice(0, 67) + '...' : pub.title,
-        detail: pub.journal,
-        time: relativeTime(Math.max(0, monthsAgo)),
-        link: '/publications',
+    if (!mounted) return []
+    return rawActivity
+      .filter((a) => isProductionVisibleActivity({ description: a.description }))
+      .slice(0, 5)
+      .map((a) => {
+        const person = a.actor ? getPersonInfo(a.actor) : null
+        return {
+          id: a.id,
+          dotColor: dotColorForType(a.type || ''),
+          actorName: person?.name ?? null,
+          description: a.description || '',
+          time: formatRelativeTime(a.timestamp),
+          link: PATHS.activity,
+        }
       })
-    })
-
-    // Papers in review
-    const inReview = publications.filter((p) => p.status === 'In Review')
-    if (inReview.length > 0) {
-      feed.push({
-        icon: FlaskConical,
-        dotColor: '#2d8a8a',
-        text: `${inReview.length} manuscript${inReview.length > 1 ? 's' : ''} under review`,
-        detail: inReview.map((p) => p.journal).join(', '),
-        time: 'Active',
-        link: '/publications',
-      })
-    }
-
-    // Active projects count
-    const activeProjects = projects.filter((p) => isProjectActive(p.status))
-    feed.push({
-      icon: FlaskConical,
-      dotColor: '#2d8a8a',
-      text: `${activeProjects.length} research projects actively underway`,
-      detail: 'CLIF consortium and MN-CCORE lab',
-      time: 'Ongoing',
-    })
-
-    // Team growth
-    feed.push({
-      icon: Users,
-      dotColor: '#ffffff',
-      text: 'CLIF Consortium expanding to 13+ sites nationwide',
-      detail: 'Multi-center ICU data infrastructure',
-      time: '2025',
-    })
-
-    return feed.slice(0, 8)
-  }, [publications, projects])
+  }, [rawActivity, mounted])
 
   return (
     <BentoCard title="Recent Activity" subtitle="Lab updates" size="span-1x2" icon={Activity} drillDown>
@@ -116,10 +83,15 @@ function ActivityFeedCard() {
               }}
             />
 
+            {items.length === 0 && (
+              <div className="py-4 text-center" style={{ fontSize: 'var(--label-size)', color: 'var(--slate)', opacity: 'var(--ink-label)' }}>
+                No recent activity yet.
+              </div>
+            )}
             {items.map((item, i) => {
               return (
                 <div
-                  key={i}
+                  key={item.id}
                   className="flex items-start gap-3 py-2.5 relative group"
                   style={{
                     borderBottom: i < items.length - 1
@@ -135,9 +107,7 @@ function ActivityFeedCard() {
                       height: '15px',
                       borderRadius: 'var(--radius-circle)',
                       background: item.dotColor,
-                      border: item.dotColor === '#ffffff'
-                        ? '1.5px solid rgba(201, 168, 76, 0.3)'
-                        : '2px solid var(--cream)',
+                      border: '2px solid var(--cream)',
                       marginTop: '2px',
                       transition: 'transform 0.2s ease',
                     }}
@@ -153,18 +123,11 @@ function ActivityFeedCard() {
                         margin: 0,
                       }}
                     >
-                      {item.text}
-                    </p>
-                    <p
-                      style={{
-                        fontSize: 'var(--label-size)',
-                        color: 'var(--slate)',
-                        fontStyle: 'italic',
-                        margin: '2px 0 0 0',
-                        opacity: 0.85,
-                      }}
-                    >
-                      {item.detail}
+                      {item.actorName ? (
+                        <span style={{ fontWeight: 500 }}>{item.actorName}</span>
+                      ) : null}
+                      {item.actorName ? ' ' : ''}
+                      {item.description}
                     </p>
                   </div>
 
@@ -189,7 +152,7 @@ function ActivityFeedCard() {
 
         {/* View all link */}
         <Link
-          to="/publications"
+          to={PATHS.activity}
           className="flex items-center gap-1 mt-3 pt-2 portal-footer-link"
           style={{
             fontSize: 'var(--label-size)',

--- a/src/components/dashboard/GrantTimelineCard.tsx
+++ b/src/components/dashboard/GrantTimelineCard.tsx
@@ -1,21 +1,9 @@
-import { memo } from 'react'
+import { memo, useMemo } from 'react'
 import { Banknote } from 'lucide-react'
 import BentoCard from './BentoCard'
-import { useGrants } from '../../hooks/useApiData'
+import { useGrantTimeline, type GrantTimelineItem } from '../../hooks/useGrantTimeline'
 
-// Grant timeline data — supplement static grants with plausible year ranges
-const grantTimelines = [
-  { mechanism: 'K23', pi: 'Ingraham', agency: 'NHLBI', startYear: 2023, endYear: 2028, proposed: false },
-  { mechanism: 'R03', pi: 'Ingraham', agency: 'NHLBI', startYear: 2024, endYear: 2026, proposed: false },
-  { mechanism: 'R01', pi: 'Ingraham', agency: 'NHLBI', startYear: 2027, endYear: 2032, proposed: true, label: 'ADHERE-LPV' },
-  { mechanism: 'R01', pi: 'Ingraham', agency: 'NHLBI', startYear: 2027, endYear: 2032, proposed: true, label: 'Provider Variation' },
-  { mechanism: 'K23', pi: 'Mesfin', agency: 'NHLBI', startYear: 2027, endYear: 2032, proposed: true, label: 'IHCA Calculator' },
-]
-
-const MIN_YEAR = 2023
-const MAX_YEAR = 2032
 const CURRENT_YEAR = new Date().getFullYear()
-const TOTAL_YEARS = MAX_YEAR - MIN_YEAR + 1
 
 function mechanismColor(mechanism: string): string {
   switch (mechanism) {
@@ -26,130 +14,216 @@ function mechanismColor(mechanism: string): string {
   }
 }
 
+interface GrantBar {
+  id: string
+  mechanism: string
+  pi: string
+  title: string
+  startYear: number
+  endYear: number
+  /** Render as a dashed outline (in-prep / proposed / submitted) vs solid (funded). */
+  proposed: boolean
+}
+
+/** Pull a 4-digit year from `YYYY-MM-DD` (or YYYY) — null if missing/unparseable. */
+function yearFrom(dateStr: string | null | undefined): number | null {
+  if (!dateStr) return null
+  const m = /^(\d{4})/.exec(dateStr)
+  return m ? parseInt(m[1], 10) : null
+}
+
+/** Last name from "First Last" or slug-style "first-last". */
+function shortPi(pi: string | null | undefined): string {
+  if (!pi) return ''
+  if (pi.includes('-')) {
+    const parts = pi.split('-')
+    const last = parts[parts.length - 1]
+    return last.charAt(0).toUpperCase() + last.slice(1)
+  }
+  const parts = pi.trim().split(/\s+/)
+  return parts.length > 1 ? parts[parts.length - 1] : parts[0]
+}
+
+function toBar(g: GrantTimelineItem): GrantBar | null {
+  const start = yearFrom(g.start_date)
+  const end = yearFrom(g.end_date)
+  if (start == null && end == null) return null
+  // Fill missing endpoints sensibly so a single-date grant still shows a bar.
+  const startYear = start ?? (end ?? CURRENT_YEAR)
+  const endYear = end ?? Math.max(startYear, CURRENT_YEAR)
+  const proposed = g.proposed === 1 || g.status === 'in_preparation' || g.status === 'submitted' || g.status === 'planning'
+  return {
+    id: g.id,
+    mechanism: g.mechanism || '—',
+    pi: shortPi(g.pi),
+    title: g.title,
+    startYear,
+    endYear,
+    proposed,
+  }
+}
+
 function GrantTimelineCard() {
-  const { data: grants = [] } = useGrants()
-  const fundedCount = grants.filter((g) => g.status === 'funded').length
-  const inPrepCount = grants.filter((g) => g.status === 'in_preparation').length
+  const { data: grants = [] } = useGrantTimeline()
+
+  const { bars, minYear, totalYears, fundedCount, inPrepCount } = useMemo(() => {
+    const allBars: GrantBar[] = []
+    let funded = 0
+    let inPrep = 0
+    for (const g of grants) {
+      if (g.status === 'funded') funded++
+      if (g.status === 'in_preparation') inPrep++
+      const bar = toBar(g)
+      if (!bar) continue
+      // Don't render speculation past 5 years from current year.
+      if (bar.startYear > CURRENT_YEAR + 5) continue
+      allBars.push(bar)
+    }
+    allBars.sort((a, b) => a.startYear - b.startYear || a.endYear - b.endYear)
+
+    if (allBars.length === 0) {
+      return { bars: allBars, minYear: CURRENT_YEAR, totalYears: 1, fundedCount: funded, inPrepCount: inPrep }
+    }
+    const minYr = Math.min(...allBars.map((b) => b.startYear), CURRENT_YEAR)
+    const maxYr = Math.max(...allBars.map((b) => b.endYear), CURRENT_YEAR)
+    return {
+      bars: allBars,
+      minYear: minYr,
+      totalYears: Math.max(1, maxYr - minYr + 1),
+      fundedCount: funded,
+      inPrepCount: inPrep,
+    }
+  }, [grants])
 
   return (
     <BentoCard title="Grant Portfolio" subtitle={`${fundedCount} funded, ${inPrepCount} in prep`} size="span-2" icon={Banknote}>
       <div className="flex flex-col h-full justify-between">
-        {/* Timeline bars */}
-        <div className="flex flex-col gap-2.5 mt-1">
-          {grantTimelines.map((g, i) => {
-            const startPct = ((g.startYear - MIN_YEAR) / TOTAL_YEARS) * 100
-            const widthPct = ((g.endYear - g.startYear + 1) / TOTAL_YEARS) * 100
-            const color = mechanismColor(g.mechanism)
+        {bars.length === 0 ? (
+          <div className="flex-1 flex items-center justify-center" style={{ minHeight: 80, fontSize: 'var(--label-size)', color: 'var(--slate)', opacity: 'var(--ink-label)' }}>
+            No grants in the timeline yet.
+          </div>
+        ) : (
+          <>
+            {/* Timeline bars */}
+            <div className="flex flex-col gap-2.5 mt-1">
+              {bars.map((g) => {
+                const startPct = ((g.startYear - minYear) / totalYears) * 100
+                const widthPct = ((g.endYear - g.startYear + 1) / totalYears) * 100
+                const color = mechanismColor(g.mechanism)
 
-            return (
-              <div key={i} className="relative" style={{ height: '26px' }}>
-                {/* Bar */}
-                <div
-                  style={{
-                    position: 'absolute',
-                    left: `${startPct}%`,
-                    width: `${widthPct}%`,
-                    top: 0,
-                    bottom: 0,
-                    borderRadius: 'var(--radius-md)',
-                    background: g.proposed
-                      ? 'transparent'
-                      : color,
-                    border: g.proposed
-                      ? `1.5px dashed ${color}`
-                      : 'none',
-                    opacity: g.proposed ? 0.85 : 0.85,
-                    display: 'flex',
-                    alignItems: 'center',
-                    paddingLeft: '8px',
-                    gap: '6px',
-                    overflow: 'hidden',
-                    transition: 'opacity 0.2s ease',
-                  }}
-                  className="hover:!opacity-100"
-                >
-                  {/* Mechanism badge */}
-                  <span
-                    style={{
-                      fontSize: '10px',
-                      fontWeight: 700,
-                      color: g.proposed ? color : '#fff',
-                      flexShrink: 0,
-                      letterSpacing: '0.02em',
-                    }}
-                  >
-                    {g.mechanism}
-                  </span>
-                  {/* PI name */}
-                  <span
-                    style={{
-                      fontSize: '10px',
-                      color: g.proposed ? 'var(--slate)' : 'rgba(255,255,255,0.8)',
-                      whiteSpace: 'nowrap',
-                      overflow: 'hidden',
-                      textOverflow: 'ellipsis',
-                    }}
-                  >
-                    {g.pi}
-                    {g.label ? ` — ${g.label}` : ''}
-                  </span>
-                </div>
-              </div>
-            )
-          })}
-        </div>
+                return (
+                  <div key={g.id} className="relative" style={{ height: '26px' }}>
+                    {/* Bar */}
+                    <div
+                      style={{
+                        position: 'absolute',
+                        left: `${startPct}%`,
+                        width: `${widthPct}%`,
+                        top: 0,
+                        bottom: 0,
+                        borderRadius: 'var(--radius-md)',
+                        background: g.proposed
+                          ? 'transparent'
+                          : color,
+                        border: g.proposed
+                          ? `1.5px dashed ${color}`
+                          : 'none',
+                        opacity: 0.85,
+                        display: 'flex',
+                        alignItems: 'center',
+                        paddingLeft: '8px',
+                        gap: '6px',
+                        overflow: 'hidden',
+                        transition: 'opacity 0.2s ease',
+                      }}
+                      className="hover:!opacity-100"
+                      title={g.title}
+                    >
+                      {/* Mechanism badge */}
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          fontWeight: 700,
+                          color: g.proposed ? color : '#fff',
+                          flexShrink: 0,
+                          letterSpacing: '0.02em',
+                        }}
+                      >
+                        {g.mechanism}
+                      </span>
+                      {/* PI name + title */}
+                      <span
+                        style={{
+                          fontSize: '10px',
+                          color: g.proposed ? 'var(--slate)' : 'rgba(255,255,255,0.8)',
+                          whiteSpace: 'nowrap',
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                        }}
+                      >
+                        {g.pi ? `${g.pi}` : ''}
+                        {g.pi && g.title ? ' — ' : ''}
+                        {g.title}
+                      </span>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
 
-        {/* Year scale */}
-        <div className="flex items-end mt-3 relative" style={{ height: '20px' }}>
-          {Array.from({ length: TOTAL_YEARS }, (_, i) => {
-            const year = MIN_YEAR + i
-            const isCurrent = year === CURRENT_YEAR
-            return (
-              <div
-                key={year}
-                className="flex-1 text-center relative"
-              >
-                {/* Current year marker */}
-                {isCurrent && (
+            {/* Year scale */}
+            <div className="flex items-end mt-3 relative" style={{ height: '20px' }}>
+              {Array.from({ length: totalYears }, (_, i) => {
+                const year = minYear + i
+                const isCurrent = year === CURRENT_YEAR
+                return (
                   <div
-                    style={{
-                      position: 'absolute',
-                      top: '-120px',
-                      left: '50%',
-                      transform: 'translateX(-50%)',
-                      width: '1.5px',
-                      height: '120px',
-                      background: 'var(--gold)',
-                      opacity: 0.85,
-                    }}
-                  />
-                )}
-                <span
-                  style={{
-                    fontSize: '10px',
-                    color: isCurrent ? 'var(--gold)' : 'var(--slate)',
-                    opacity: isCurrent ? 1 : 0.85,
-                    fontWeight: isCurrent ? 700 : 400,
-                  }}
-                >
-                  {year % 2 === 1 ? `'${String(year).slice(2)}` : ''}
-                </span>
-              </div>
-            )
-          })}
-        </div>
+                    key={year}
+                    className="flex-1 text-center relative"
+                  >
+                    {/* Current year marker */}
+                    {isCurrent && (
+                      <div
+                        style={{
+                          position: 'absolute',
+                          top: '-120px',
+                          left: '50%',
+                          transform: 'translateX(-50%)',
+                          width: '1.5px',
+                          height: '120px',
+                          background: 'var(--gold)',
+                          opacity: 0.85,
+                        }}
+                      />
+                    )}
+                    <span
+                      style={{
+                        fontSize: '10px',
+                        color: isCurrent ? 'var(--gold)' : 'var(--slate)',
+                        opacity: isCurrent ? 1 : 0.85,
+                        fontWeight: isCurrent ? 700 : 400,
+                      }}
+                    >
+                      {year % 2 === 1 ? `'${String(year).slice(2)}` : ''}
+                    </span>
+                  </div>
+                )
+              })}
+            </div>
 
-        {/* Legend */}
-        <div className="flex items-center gap-4 mt-2">
-          <div className="flex items-center gap-1.5">
-            <div style={{ width: 14, height: 6, borderRadius: 'var(--radius-sm)', background: '#2d8a8a' }} />
-            <span style={{ fontSize: '10px', color: 'var(--slate)', opacity: 0.75 }}>Active</span>
-          </div>
-          <div className="flex items-center gap-1.5">
-            <div style={{ width: 14, height: 6, borderRadius: 'var(--radius-sm)', border: '1.5px dashed #2d8a8a', opacity: 0.85 }} />
-            <span style={{ fontSize: '10px', color: 'var(--slate)', opacity: 0.75 }}>Proposed</span>
-          </div>
-        </div>
+            {/* Legend */}
+            <div className="flex items-center gap-4 mt-2">
+              <div className="flex items-center gap-1.5">
+                <div style={{ width: 14, height: 6, borderRadius: 'var(--radius-sm)', background: '#2d8a8a' }} />
+                <span style={{ fontSize: '10px', color: 'var(--slate)', opacity: 0.75 }}>Funded</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div style={{ width: 14, height: 6, borderRadius: 'var(--radius-sm)', border: '1.5px dashed #2d8a8a', opacity: 0.85 }} />
+                <span style={{ fontSize: '10px', color: 'var(--slate)', opacity: 0.75 }}>In prep / Submitted</span>
+              </div>
+            </div>
+          </>
+        )}
       </div>
     </BentoCard>
   )

--- a/src/components/dashboard/UpcomingCard.tsx
+++ b/src/components/dashboard/UpcomingCard.tsx
@@ -1,7 +1,8 @@
 import { memo, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { Calendar, AlertCircle, ArrowRight, ListChecks, CalendarOff, UserCheck } from 'lucide-react'
-import { useMeetingsApi, useActionItems, useMeetingCadence } from '../../hooks/useApiData'
+import { useMeetingsApi, useActionItems, useMeetingCadence, useTasks } from '../../hooks/useApiData'
+import { useGrantTimeline } from '../../hooks/useGrantTimeline'
 import { getMeetingFacilitator } from '../../lib/facilitator'
 import { getPersonInfo } from '../../data/team'
 import BentoCard from './BentoCard'
@@ -10,71 +11,91 @@ import { PATHS } from '../../constants/paths'
 interface Deadline {
   date: string
   label: string
-  type: 'grant' | 'milestone' | 'review'
+  type: 'task' | 'grant' | 'milestone'
   daysUntil: number
 }
 
-function generateDeadlines(): Deadline[] {
-  // Generate plausible upcoming deadlines based on real grant/project data
-  const deadlines: Deadline[] = [
-    {
-      date: formatDate(daysFromNow(12)),
-      label: 'R01 ADHERE-LPV LOI due',
-      type: 'grant',
-      daysUntil: 12,
-    },
-    {
-      date: formatDate(daysFromNow(28)),
-      label: 'LPV Variation revision response',
-      type: 'review',
-      daysUntil: 28,
-    },
-    {
-      date: formatDate(daysFromNow(45)),
-      label: 'CLIF annual meeting abstract',
-      type: 'milestone',
-      daysUntil: 45,
-    },
-    {
-      date: formatDate(daysFromNow(67)),
-      label: 'K23 progress report',
-      type: 'grant',
-      daysUntil: 67,
-    },
-    {
-      date: formatDate(daysFromNow(-3)),
-      label: 'CCI-ARDS data freeze',
-      type: 'milestone',
-      daysUntil: -3,
-    },
-  ]
-
-  return deadlines.sort((a, b) => a.daysUntil - b.daysUntil)
-}
-
-function daysFromNow(days: number): Date {
-  const d = new Date()
-  d.setDate(d.getDate() + days)
-  return d
-}
-
-function formatDate(d: Date): string {
+function formatDateShort(d: Date): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }
 
 function typeColor(type: Deadline['type']): string {
   switch (type) {
+    case 'task': return 'var(--teal)'
     case 'grant': return 'var(--gold)'
-    case 'review': return 'var(--teal)'
     case 'milestone': return 'var(--slate)'
   }
 }
 
 function UpcomingCard() {
-  const deadlines = generateDeadlines()
   const { data: meetings = [] } = useMeetingsApi()
   const { data: allActionItems = [] } = useActionItems()
   const { data: cadence } = useMeetingCadence()
+  const { data: tasks = [] } = useTasks()
+  const { data: grants = [] } = useGrantTimeline()
+
+  // Aggregate real deadlines from open tasks (with due_date) + grant milestones.
+  // Cap to 5 most-urgent: overdue first (most-overdue first), then ascending by days-until-due.
+  const deadlines = useMemo<Deadline[]>(() => {
+    const now = new Date()
+    const items: Deadline[] = []
+
+    // Open tasks with a due_date (skip completed)
+    for (const t of tasks) {
+      if (!t.due_date || t.completed) continue
+      const due = new Date(t.due_date + 'T23:59:59')
+      const daysUntil = Math.ceil((due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+      items.push({
+        date: formatDateShort(due),
+        label: t.title || t.description || 'Untitled task',
+        type: 'task',
+        daysUntil,
+      })
+    }
+
+    // Grant milestones (target_date)
+    for (const g of grants) {
+      for (const m of g.milestones || []) {
+        if (!m.target_date) continue
+        if (m.status === 'completed') continue
+        const due = new Date(m.target_date + 'T23:59:59')
+        const daysUntil = Math.ceil((due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+        items.push({
+          date: formatDateShort(due),
+          label: `${g.mechanism}: ${m.title}`,
+          type: 'milestone',
+          daysUntil,
+        })
+      }
+    }
+
+    // Grant submission targets (end_date) for grants in submission lifecycle
+    for (const g of grants) {
+      if (!g.end_date) continue
+      // Only surface grants that haven't yet been funded/closed/declined
+      if (g.status === 'funded' || g.status === 'closed' || g.status === 'declined') continue
+      const due = new Date(g.end_date + 'T23:59:59')
+      const daysUntil = Math.ceil((due.getTime() - now.getTime()) / (1000 * 60 * 60 * 24))
+      items.push({
+        date: formatDateShort(due),
+        label: `${g.mechanism} ${g.pi || ''} — ${g.title}`.trim(),
+        type: 'grant',
+        daysUntil,
+      })
+    }
+
+    // Sort: overdue first (negative days, most overdue first), then ascending by days-until-due
+    items.sort((a, b) => {
+      const aOver = a.daysUntil < 0
+      const bOver = b.daysUntil < 0
+      if (aOver && bOver) return a.daysUntil - b.daysUntil  // -10 before -2
+      if (aOver) return -1
+      if (bOver) return 1
+      return a.daysUntil - b.daysUntil  // ascending future
+    })
+
+    return items.slice(0, 5)
+  }, [tasks, grants])
 
   // Find the next upcoming meeting — closest future date wins, regardless of status
   const nextMeeting = useMemo(() => {
@@ -205,6 +226,11 @@ function UpcomingCard() {
       )}
 
       <div className="flex flex-col gap-1">
+        {deadlines.length === 0 && (
+          <div className="py-3 text-center" style={{ fontSize: 'var(--label-size)', color: 'var(--slate)', opacity: 'var(--ink-label)' }}>
+            No upcoming deadlines
+          </div>
+        )}
         {deadlines.map((d, i) => {
           const isUrgent = d.daysUntil >= 0 && d.daysUntil <= 30
           const isOverdue = d.daysUntil < 0


### PR DESCRIPTION
Wave 2 of audit/2026-04-28 fix phase. Per Decision D2: wire all 4 fake-data cards to real APIs. LO-1 (citations) deferred to Bundle G (separate PR).

## Findings closed

- **LO-2** (P0) — UpcomingCard fake R01/K23/CCI deadlines list replaced with real data via `useTasks()` (open tasks with due_date) + `useGrantTimeline()` (milestones via target_date + grant submission targets via end_date). Cap to 5 most-urgent: overdue first, then ascending by days-until-due. Empty state added. Next-meeting block intact.
- **LO-3** (P0) — GrantTimelineCard hardcoded `grantTimelines` array dropped; bars now derive from real `useGrantTimeline()` data. Filtered to startYear <= currentYear+5. Sorted by start year ASC. Funded → solid; in_preparation/submitted/planning OR proposed=1 → dashed. Empty state added.
- **LO-4** (P0) — ActivityFeedCard hardcoded 'CLIF Consortium expanding' marketing copy replaced with real `useActivity(20)` feed, filtered via `isProductionVisibleActivity`, sliced to 5. Each row: type-coded dot, actor name (resolved via `getPersonInfo(emailToSlug(actor))`), description, relative timestamp. 'View all' footer routed to `PATHS.activity`.

## Hook discoveries
- `useActivity()` already exists at `useApiData.ts:271` — no new hook.
- `useGrantTimeline()` exists at `src/hooks/useGrantTimeline.ts` — exposes full grant rows with dates + milestones (which `useGrants()` strips).
- `useDeadlines()` does NOT exist; Deadlines page uses `useTasks()` + `useGrantTimeline()` directly. Followed same pattern.

## Data shape surprise
`useGrants()` from `useApiData.ts` discards `start_date`/`end_date` in `rowToGrant()`. Switched LO-3 to `useGrantTimeline()` (different endpoint, same purpose) so date fields are preserved.

## Verification
- `npm run build` clean (TypeScript + Vite) at every commit.
- All 3 findings verified STILL BROKEN against current source.
- See `audit/2026-04-28/progress-log.md` for per-finding evidence (committed separately to main as `62501e37`).