### PR TITLE
Bundle G: Citations infrastructure (LO-1, schema v54)

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -611,7 +611,7 @@ app.post('/api/projects/:slug/documents/:docId/delete', (c) => handleDeleteProje
 app.post('/api/projects/:slug', (c) => handleUpdateProject(c.req.param('slug'), R(c), USER(c), E(c)));
 
 // Team
-app.put('/api/team/:slug', (c) => handleUpdateTeamMember(c.req.param('slug'), R(c), USER(c), E(c)));
+app.put('/api/team/:slug', (c) => handleUpdateTeamMember(c.req.param('slug'), R(c), USER(c), E(c), c.get('apiKeyValid') === true));
 
 // Tasks — specific-before-generic
 app.post('/api/tasks/sync-bulk', (c) => handleSyncBulkTasks(R(c), USER(c), E(c)));

--- a/api/index.ts
+++ b/api/index.ts
@@ -13,6 +13,7 @@ import { handleTasks, handleActionItems, handleOverdueCount, handleUpdateTaskSta
 import { handleProjects, handleCreateProject, handleGetComments, handleGetProjectUpdates, handleProjectHealth, handleRecentUpdates, handleUpdateProject, handleDeleteProject, handleGetDeletedProjectsSince, handleAddComment, handlePostProjectUpdate, handleGetMilestones, handleUpdateMilestoneNote, handleUpdateMilestoneCompletion } from './routes/projects';
 import { handleMeetings, handleNextMeeting, handleGetMeeting, handleGetAgendaItems, handleAddAgendaItem, handleReorderAgenda, handleCreateMeeting, handleUpdateMeetingNotes, handleMeetingPrep, handleGenerateAgenda } from './routes/meetings';
 import { handlePublications, handleGrants, handleCollaborationGraph, handleStats, handleGrantsTimeline, handleUpdateGrant } from './routes/publications';
+import { handleCitations } from './routes/citations';
 import { handleTeam, handleTeamSlugs, handleCVData, handleUpdateTeamMember } from './routes/team';
 import { handleDigest, handleDigestDates, handleUpdateDigestStatus, handleCreateDigestPaper, handleGetDigestComments, handleCreateDigestComment, handleDigestCommentCounts } from './routes/digest';
 import { handleIdeas, handleCreateIdea, handleUpdateIdea, handleVoteIdea } from './routes/ideas';
@@ -455,6 +456,7 @@ app.get('/api/team/slugs', (c) => handleTeamSlugs(E(c)));
 app.get('/api/team/pulse', (c) => handleTeamPulse(U(c), E(c)));
 app.get('/api/graph/collaboration', (c) => handleCollaborationGraph(E(c)));
 app.get('/api/stats', (c) => handleStats(E(c)));
+app.get('/api/citations', (c) => handleCitations(E(c)));
 app.get('/api/activity', (c) => handleActivity(U(c), E(c)));
 app.get('/api/activity/heatmap', (c) => handleActivityHeatmap(U(c), E(c)));
 app.get('/api/tasks/overdue-count', (c) => handleOverdueCount(U(c), E(c)));

--- a/api/routes/citations.ts
+++ b/api/routes/citations.ts
@@ -1,0 +1,63 @@
+// Citations endpoint — lab-wide Google Scholar totals.
+//
+// Decision: D2-followup (audit/2026-04-28/DECISIONS-RESOLVED.md). Replaces
+// hardcoded `totalCitations = 2626` on the Lab Overview StatsCard with a
+// real-data SUM over team_members.citation_count.
+//
+// Pipeline (PB-side, separate from this code):
+//   weekly cron on home laptop iterates `team_members WHERE scholar_id IS
+//   NOT NULL`, uses `scholarly` Python library to fetch each profile,
+//   writes citation_count + h_index + last_scholar_refresh back to D1 via
+//   PUT /api/team/:slug.
+//
+// Hub serves the aggregated read here. SUM() in sqlite skips NULL values
+// natively, so partial coverage (e.g. 5 of 19 members fetched) renders
+// correctly without extra coalescing.
+//
+// Edge cache 1 hour: citation counts move on a weekly cadence at most;
+// no point hitting D1 every dashboard mount.
+//
+// Schema dependency: api/schema-v54-team-citations.sql (citation_count,
+// h_index, last_scholar_refresh on team_members).
+
+import { corsHeaders } from '../helpers'
+import type { Env } from '../helpers'
+
+interface CitationsAggregateRow {
+  total: number | null
+  members_with_data: number
+  members_total: number
+  last_refresh: string | null
+}
+
+// GET /api/citations
+export async function handleCitations(env: Env): Promise<Response> {
+  // Single round-trip — sqlite computes SUM/MAX/COUNT in one pass. We
+  // return total=0 + members_with_data=0 if the schema migration hasn't
+  // run yet (CASE-guarded for forward-compat), but with v54 applied the
+  // columns exist and the query returns meaningful data.
+  const row = await env.DB.prepare(
+    `SELECT
+       SUM(citation_count) AS total,
+       SUM(CASE WHEN citation_count IS NOT NULL THEN 1 ELSE 0 END) AS members_with_data,
+       COUNT(*) AS members_total,
+       MAX(last_scholar_refresh) AS last_refresh
+     FROM team_members`
+  ).first<CitationsAggregateRow>()
+
+  const body = {
+    total: row?.total ?? 0,
+    last_refresh: row?.last_refresh ?? null,
+    members_with_data: row?.members_with_data ?? 0,
+    members_total: row?.members_total ?? 0,
+  }
+
+  return new Response(JSON.stringify({ data: body }), {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json',
+      'Cache-Control': 'public, max-age=3600, s-maxage=3600',
+      ...corsHeaders,
+    },
+  })
+}

--- a/api/routes/team.ts
+++ b/api/routes/team.ts
@@ -46,24 +46,74 @@ const SELF_EDIT_FIELDS = ['bio', 'photo_url', 'scholar_id', 'title', 'department
 // whole lab.
 const ADMIN_ONLY_FIELDS = ['role', 'member_type'] as const
 
-const ALL_ALLOWED_FIELDS: readonly string[] = [...SELF_EDIT_FIELDS, ...ADMIN_ONLY_FIELDS]
+// Citation cache fields — written ONLY by the PB-side scholarly cron via
+// X-API-Key (Bearer PB_API_KEY) auth, never by browser users. See
+// scripts/citations-scholar-stub.md. Schema: api/schema-v54-team-citations.sql.
+const CITATION_FIELDS = ['citation_count', 'h_index', 'last_scholar_refresh'] as const
+
+const ALL_ALLOWED_FIELDS: readonly string[] = [
+  ...SELF_EDIT_FIELDS,
+  ...ADMIN_ONLY_FIELDS,
+  ...CITATION_FIELDS,
+]
 
 // PUT /api/team/:slug — update a team member's profile.
 // Authorization:
+//   - Caller authenticated via PB_API_KEY (X-API-Key / Bearer header):
+//     can update CITATION_FIELDS only (used by the weekly scholarly cron).
+//     Owner / PI gates do NOT apply — the cron has no JWT identity.
 //   - User editing their OWN row (slug derived from JWT email == path slug):
 //     can update SELF_EDIT_FIELDS only
 //   - User in lab_settings.pi_emails:
-//     can update any row, including ADMIN_ONLY_FIELDS
+//     can update any row, including ADMIN_ONLY_FIELDS (NOT citation fields —
+//     those flow only from the cron, never hand-edited).
 //   - Anyone else: 403
 export async function handleUpdateTeamMember(
   slug: string,
   request: Request,
   user: AuthUser,
   env: Env,
+  apiKeyAuth: boolean = false,
 ): Promise<Response> {
-  // Auth boundary. Anonymous fallback identity has email='anonymous';
-  // reject before any DB write. (REQUIRE_AUTH=1 in prod also blocks at
-  // middleware level, but this is defense-in-depth.)
+  // API-key auth path (PB scholarly cron). No JWT identity — cron writes
+  // CITATION_FIELDS only.
+  if (apiKeyAuth) {
+    const body = await request.json() as Record<string, unknown>;
+    const updates: string[] = [];
+    const values: (string | number | null)[] = [];
+
+    for (const [key, val] of Object.entries(body)) {
+      if (!CITATION_FIELDS.includes(key as typeof CITATION_FIELDS[number])) {
+        return error(`Field "${key}" is not writable via API key`, 403);
+      }
+      updates.push(`${key} = ?`);
+      values.push(val as string | number | null);
+    }
+
+    if (updates.length === 0) {
+      return error('No valid fields to update', 400);
+    }
+
+    values.push(slug);
+    const result = await env.DB.prepare(
+      `UPDATE team_members SET ${updates.join(', ')} WHERE slug = ?`
+    ).bind(...values).run();
+
+    if (result.meta.changes === 0) {
+      return error('Team member not found', 404);
+    }
+
+    // Citation cron writes are mechanical; skip activity_log spam. (Cron
+    // runs weekly across ~20 members → would generate 20 activity rows
+    // every Monday morning for no operational signal.)
+    const updated = await env.DB.prepare('SELECT * FROM team_members WHERE slug = ?').bind(slug).first();
+    return json({ data: updated });
+  }
+
+  // Browser/JWT auth path — original owner-or-PI flow.
+  // Anonymous fallback identity has email='anonymous'; reject before any
+  // DB write. (REQUIRE_AUTH=1 in prod also blocks at middleware level,
+  // but this is defense-in-depth.)
   if (!user.email || user.email === 'anonymous') {
     return error('Authentication required', 401);
   }
@@ -84,6 +134,10 @@ export async function handleUpdateTeamMember(
 
   for (const [key, val] of Object.entries(body)) {
     if (!ALL_ALLOWED_FIELDS.includes(key)) continue
+    // Citation fields can only be written by the PB cron (API key).
+    if (CITATION_FIELDS.includes(key as typeof CITATION_FIELDS[number])) {
+      return error(`Field "${key}" is only writable by the citations cron`, 403);
+    }
     // Admin-only field guard.
     if (ADMIN_ONLY_FIELDS.includes(key as typeof ADMIN_ONLY_FIELDS[number]) && !isPi) {
       return error(`Field "${key}" can only be set by a PI`, 403);

--- a/api/schema-v54-team-citations.sql
+++ b/api/schema-v54-team-citations.sql
@@ -1,0 +1,29 @@
+-- v54 (2026-04-28): per-author Google Scholar citation cache on team_members.
+--
+-- Decision: D2-followup (audit/2026-04-28/DECISIONS-RESOLVED.md). Lab Overview
+-- StatsCard.totalCitations was hardcoded `2626`. Wire to real data.
+--
+-- Source-of-truth pipeline (PB-side, OUT OF SCOPE for this migration):
+--   weekly cron on home laptop iterates `team_members WHERE scholar_id IS NOT NULL`,
+--   uses `scholarly` Python library to fetch each author's Google Scholar profile,
+--   writes citation_count + h_index + last_scholar_refresh back to D1 via
+--   PUT /api/team/:slug.
+--
+-- Hub-side endpoint:
+--   GET /api/citations returns SUM(citation_count) + MAX(last_scholar_refresh)
+--   so the dashboard renders the lab-wide total + a "Updated N days ago" subtitle.
+--
+-- All three columns are nullable. NULL = "no scholarly fetch has run yet for
+-- this author." A NULL on citation_count is excluded from the SUM (sqlite3
+-- skips NULL in SUM by default), so partial-coverage states render correctly.
+--
+-- Cross-repo coordination: brain.db does NOT mirror citation_count / h_index /
+-- last_scholar_refresh — these fields live only in D1. The PB cron writes via
+-- the Hub API, not via brain.db sync. No enums.py / shared-schema-registry
+-- update needed.
+--
+-- Additive. Safe to apply to production D1.
+
+ALTER TABLE team_members ADD COLUMN citation_count INTEGER DEFAULT NULL;
+ALTER TABLE team_members ADD COLUMN h_index INTEGER DEFAULT NULL;
+ALTER TABLE team_members ADD COLUMN last_scholar_refresh TIMESTAMP DEFAULT NULL;

--- a/scripts/citations-scholar-stub.md
+++ b/scripts/citations-scholar-stub.md
@@ -1,0 +1,207 @@
+# Citations cron — Google Scholar via `scholarly` (stub design)
+
+> **Decision**: D2-followup — `audit/2026-04-28/DECISIONS-RESOLVED.md`.
+> **Closes**: LO-1 — `audit/2026-04-28/reports/05-lab-overview.md` (StatsCard.totalCitations was hardcoded `2626`).
+>
+> **Status**: Hub-side infrastructure shipped (schema v54 + `/api/citations` + `useCitations()` + StatsCard wire). PB-side cron design captured here. Nick implements the cron on the home laptop; this doc is the spec.
+
+## Why scholarly + per-author + weekly
+
+- **Per-author**: each `team_members` row has a `scholar_id` field already. Scholarly fetches the author's profile in one call and returns `citedby` (citation_count) + `hindex`. Aggregating per-publication via Semantic Scholar (the original recommendation) requires a separate call per pub and merges into a noisier surface.
+- **Weekly cadence**: citation counts move on roughly that timescale. Daily is wasteful; monthly is too stale for a marquee dashboard tile. Run Monday early morning so the count is fresh for the work week.
+- **Home laptop, not Hub server**: scholarly hits Google Scholar, which routinely rate-limits / blocks data-center IPs. Residential IPs (home laptop) work reliably. Hub Workers can't reliably scrape Scholar.
+
+## Schema (already shipped)
+
+`api/schema-v54-team-citations.sql` — three nullable columns on `team_members`:
+
+```sql
+ALTER TABLE team_members ADD COLUMN citation_count INTEGER DEFAULT NULL;
+ALTER TABLE team_members ADD COLUMN h_index INTEGER DEFAULT NULL;
+ALTER TABLE team_members ADD COLUMN last_scholar_refresh TIMESTAMP DEFAULT NULL;
+```
+
+Deploy via:
+```bash
+npx wrangler d1 execute mnccore-lab --remote --file=api/schema-v54-team-citations.sql
+```
+
+## Hub endpoints
+
+### Read (already shipped)
+
+`GET /api/citations`:
+```json
+{
+  "data": {
+    "total": 2842,                          // SUM(citation_count)
+    "last_refresh": "2026-04-28T07:14:33Z", // MAX(last_scholar_refresh)
+    "members_with_data": 14,                // COUNT WHERE citation_count IS NOT NULL
+    "members_total": 19                     // total team rows
+  }
+}
+```
+
+Edge-cached 1h. Public — no auth required (matches `/api/team`, `/api/stats`).
+
+### Write (extended in same PR)
+
+`PUT /api/team/:slug` accepts the citation fields ONLY when authenticated via `Bearer PB_API_KEY` (X-API-Key path):
+
+```json
+{
+  "citation_count": 312,
+  "h_index": 8,
+  "last_scholar_refresh": "2026-04-28T07:14:33Z"
+}
+```
+
+Request:
+```http
+PUT /api/team/nick-ingraham HTTP/1.1
+Authorization: Bearer <PB_API_KEY>
+Content-Type: application/json
+
+{ "citation_count": 312, "h_index": 8, "last_scholar_refresh": "2026-04-28T07:14:33Z" }
+```
+
+Browser users (CF Access JWT) can NOT write these fields — even PI gets a 403 if they try. Citations are mechanical / cron-only data.
+
+## Cron design
+
+### Where
+
+Home laptop, alongside other PB scheduled scripts (e.g. `scripts/scheduled/meeting_automation.py`). Pick a path like `scripts/scheduled/citations_refresh.py`.
+
+### Schedule
+
+Weekly on Monday, ~6am CT (after sync windows but before the workday). Use existing PB scheduler infrastructure — don't roll a new one. Add to whatever drives the other weekly jobs.
+
+### Loop
+
+```python
+#!/usr/bin/env python3
+"""
+Weekly cron: fetch Google Scholar profile for every team member with a
+scholar_id and write citation_count + h_index back to the Hub via the
+PB-API-key path on PUT /api/team/:slug.
+
+Reads team roster from D1 (NOT brain.db — citations are Hub-only,
+deliberately not mirrored to brain.db per shared-schema-registry).
+"""
+import os
+import time
+from datetime import datetime, timezone
+from typing import Optional
+
+import requests
+from scholarly import scholarly  # pip install scholarly
+
+HUB_BASE = "https://mn-ccore-lab.pages.dev"
+PB_API_KEY = os.environ["PB_API_KEY"]  # same secret used by hub_ai_listener.py
+HEADERS = {
+    "Authorization": f"Bearer {PB_API_KEY}",
+    "Content-Type": "application/json",
+}
+
+THROTTLE_SECONDS = 30  # be polite to Scholar; 19 members × 30s ≈ 10min total
+
+
+def list_team_with_scholar() -> list[dict]:
+    """Pull team_members slugs + scholar_ids from the Hub."""
+    r = requests.get(f"{HUB_BASE}/api/team", timeout=15)
+    r.raise_for_status()
+    return [m for m in r.json()["data"] if m.get("scholar_id")]
+
+
+def fetch_scholar(scholar_id: str) -> Optional[dict]:
+    """Return {citation_count, h_index} or None on failure."""
+    try:
+        author = scholarly.search_author_id(scholar_id)
+        # `fill` populates indices; without it we'd only have a stub.
+        author = scholarly.fill(author, sections=["indices"])
+        return {
+            "citation_count": int(author.get("citedby", 0)),
+            "h_index": int(author.get("hindex", 0)),
+        }
+    except Exception as e:
+        print(f"  ! scholarly failed for {scholar_id}: {e}")
+        return None
+
+
+def push_to_hub(slug: str, payload: dict) -> bool:
+    """PUT citation fields back. Returns True on 2xx."""
+    body = {
+        **payload,
+        "last_scholar_refresh": datetime.now(timezone.utc).isoformat(),
+    }
+    r = requests.put(
+        f"{HUB_BASE}/api/team/{slug}",
+        json=body,
+        headers=HEADERS,
+        timeout=15,
+    )
+    if r.ok:
+        return True
+    print(f"  ! Hub PUT failed for {slug}: {r.status_code} {r.text[:200]}")
+    return False
+
+
+def main() -> None:
+    members = list_team_with_scholar()
+    print(f"Refreshing citations for {len(members)} members…")
+    ok = fail = 0
+    for m in members:
+        slug = m["slug"]
+        sid = m["scholar_id"]
+        print(f"  {slug} ({sid})")
+        result = fetch_scholar(sid)
+        if not result:
+            fail += 1
+            continue
+        if push_to_hub(slug, result):
+            ok += 1
+        else:
+            fail += 1
+        time.sleep(THROTTLE_SECONDS)
+    print(f"Done. ok={ok} fail={fail}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+## Failure modes + fallbacks
+
+### Scholar blocks the IP
+
+Scholar occasionally returns CAPTCHA pages or 429s. `scholarly` raises on these. Mitigations, in order of escalation:
+
+1. **Lower frequency**: weekly is already conservative; bump to fortnightly if blocks recur.
+2. **Throttle harder**: increase `THROTTLE_SECONDS` from 30 → 60 → 120 (lab is small, total run-time still bounded).
+3. **Proxy rotation**: scholarly supports `ProxyGenerator` with `FreeProxies` or `ScraperAPI`. Library docs: <https://scholarly.readthedocs.io/en/stable/quickstart.html#using-proxies>.
+4. **Stale-warning chip**: the StatsCard already renders an "Updated N weeks ago" subtitle when `last_refresh > 14d`. If the cron is dead, the dashboard surfaces it. No silent rot.
+
+### `scholar_id` is wrong / outdated
+
+`scholarly.search_author_id` returns 404-ish (raises `MaxTriesExceededException`). Cron logs the failure + moves on. The author's `citation_count` stays at its last-known value. Nick can fix `scholar_id` on `/portal/profile`.
+
+### Single bad row blocks the run
+
+The loop catches per-author exceptions (`except Exception`) and continues. One failure doesn't poison the rest.
+
+## What this doc does NOT cover
+
+- The cron is **not** implemented in this PR. This doc is the spec; Nick wires it up on the PB side using existing scheduler infrastructure.
+- brain.db does **not** mirror citation_count / h_index / last_scholar_refresh. Decision: citations are a Hub-only read-side concern, not a sync-shared field. `enums.py` and `shared-schema-registry.md` do not need updates.
+- `scholarly` is a third-party scraper of `scholar.google.com`. Google does not publish a stable API for this. If/when scholarly breaks, fallback options include OpenAlex (`https://api.openalex.org/authors/{orcid}`) or Semantic Scholar Author endpoint.
+
+## File audit checklist (Nick when implementing)
+
+- [ ] Confirm `PB_API_KEY` secret is set on home laptop env.
+- [ ] Add `scholarly` to PB Python env: `pip install scholarly`.
+- [ ] Create `scripts/scheduled/citations_refresh.py` per loop above.
+- [ ] Schedule weekly Monday 6am CT (use existing scheduler hook).
+- [ ] First run: invoke manually, confirm `team_members` rows update + dashboard tile reads non-zero.
+- [ ] After 14d: confirm "Updated N weeks ago" subtitle DOES NOT appear (cron is current).
+- [ ] After 14d of artificial pause: confirm subtitle DOES appear (stale signal works).

--- a/src/components/dashboard/StatsCard.tsx
+++ b/src/components/dashboard/StatsCard.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react'
 import { Users, FlaskConical, FileText, Award } from 'lucide-react'
 import { useCountUp } from '../../hooks/useCountUp'
 import BentoCard from './BentoCard'
-import { usePublications, useProjects, useTeam } from '../../hooks/useApiData'
+import { usePublications, useProjects, useTeam, useCitations } from '../../hooks/useApiData'
 import { useDashboardMounted } from '../../pages/Dashboard'
 import { isProjectActive } from '../../lib/taskConstants'
 import type { LucideIcon } from 'lucide-react'
@@ -12,13 +12,25 @@ interface StatItem {
   value: number
   label: string
   suffix?: string
+  /**
+   * If set, overrides the rendered number. Used by the citations stat to
+   * show "—" when no scholarly fetch has run yet — useCountUp would render
+   * "0" otherwise, which reads as a real number.
+   */
+  displayOverride?: string
+  /**
+   * Native title attribute for hover hint. Used by the citations stat to
+   * explain "—" or surface freshness info.
+   */
+  tooltip?: string
 }
 
-function MiniStat({ icon: Icon, value, label, suffix = '', delay }: StatItem & { delay: number }) {
+function MiniStat({ icon: Icon, value, label, suffix = '', delay, displayOverride, tooltip }: StatItem & { delay: number }) {
   const { count, ref } = useCountUp(value, 1800 + delay)
+  const display = displayOverride ?? `${count}${suffix}`
 
   return (
-    <div ref={ref} className="flex items-center gap-2.5 py-2">
+    <div ref={ref} className="flex items-center gap-2.5 py-2" title={tooltip}>
       <div
         style={{
           width: 32,
@@ -42,7 +54,7 @@ function MiniStat({ icon: Icon, value, label, suffix = '', delay }: StatItem & {
             lineHeight: 1.1,
           }}
         >
-          {count}{suffix}
+          {display}
         </div>
         <div
           style={{
@@ -58,26 +70,83 @@ function MiniStat({ icon: Icon, value, label, suffix = '', delay }: StatItem & {
   )
 }
 
+// "Updated 3 days ago" / "Updated 2 weeks ago" / "Updated just now".
+// Resolution: hours / days / weeks. Returns null for unparseable input
+// or "in the future" timestamps (clock-skew defense).
+function formatRelativeRefresh(iso: string | null): string | null {
+  if (!iso) return null
+  const t = Date.parse(iso)
+  if (Number.isNaN(t)) return null
+  const diffMs = Date.now() - t
+  if (diffMs < 0) return null
+  const hours = diffMs / (1000 * 60 * 60)
+  if (hours < 1) return 'Updated just now'
+  if (hours < 24) {
+    const h = Math.floor(hours)
+    return `Updated ${h} hour${h === 1 ? '' : 's'} ago`
+  }
+  const days = Math.floor(hours / 24)
+  if (days < 14) return `Updated ${days} day${days === 1 ? '' : 's'} ago`
+  const weeks = Math.floor(days / 7)
+  return `Updated ${weeks} week${weeks === 1 ? '' : 's'} ago`
+}
+
+const STALE_AFTER_DAYS = 14
+
 function StatsCard() {
   const mounted = useDashboardMounted()
   const { data: publications = [] } = usePublications(undefined, { enabled: mounted })
   const { data: projects = [] } = useProjects(undefined, { enabled: mounted })
   const { data: team = [] } = useTeam({ enabled: mounted })
+  const { data: citations, isLoading: citationsLoading } = useCitations({ enabled: mounted })
 
   const teamSize = team.length
   const activeProjects = projects.filter((p) => isProjectActive(p.status)).length
   const inReview = publications.filter((p) => p.status === 'In Review').length
-  const totalCitations = 2626
+
+  // Citations rendering rules (LO-1 / D2-followup):
+  //   1. Loading -> show "…"; do NOT render 0 (would read as "no citations").
+  //   2. members_with_data === 0 (no scholarly fetch ever) -> "—" + tooltip.
+  //   3. Stale > 14d -> add "Updated N weeks ago" subtitle on BentoCard.
+  let citationDisplay: string | undefined
+  let citationTooltip: string | undefined
+  let citationCountValue = 0
+  let staleSubtitle: string | undefined
+
+  if (citationsLoading || !mounted) {
+    citationDisplay = '…'
+  } else if (!citations || citations.members_with_data === 0) {
+    citationDisplay = '—'
+    citationTooltip = 'Citations collected weekly via Google Scholar. No data yet.'
+  } else {
+    citationCountValue = citations.total
+    const refreshLabel = formatRelativeRefresh(citations.last_refresh)
+    if (refreshLabel) {
+      const refreshedAt = citations.last_refresh ? Date.parse(citations.last_refresh) : NaN
+      const ageDays = Number.isNaN(refreshedAt) ? 0 : (Date.now() - refreshedAt) / (1000 * 60 * 60 * 24)
+      if (ageDays > STALE_AFTER_DAYS) {
+        staleSubtitle = refreshLabel
+        citationTooltip = `${refreshLabel} — Google Scholar weekly cron may be lagging.`
+      }
+    }
+  }
 
   const stats: StatItem[] = [
     { icon: Users, value: teamSize, label: 'Team members' },
     { icon: FlaskConical, value: activeProjects, label: 'Active projects' },
     { icon: FileText, value: inReview, label: 'Papers in review' },
-    { icon: Award, value: totalCitations, label: 'Total citations', suffix: '+' },
+    {
+      icon: Award,
+      value: citationCountValue,
+      label: 'Total citations',
+      suffix: '+',
+      displayOverride: citationDisplay,
+      tooltip: citationTooltip,
+    },
   ]
 
   return (
-    <BentoCard title="At a Glance" size="span-1">
+    <BentoCard title="At a Glance" size="span-1" subtitle={staleSubtitle}>
       <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
         {stats.map((stat, i) => (
           <MiniStat key={stat.label} {...stat} delay={i * 120} />

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -18,6 +18,7 @@ import {
   fetchProjects,
   fetchGrants,
   fetchStats,
+  fetchCitations,
   fetchTasks,
   fetchIdeas,
   fetchCalendarEvents,
@@ -225,6 +226,32 @@ export function useStats() {
       }
     },
     staleTime: STALE_TIME,
+  })
+}
+
+// Lab-wide Google Scholar citations aggregate.
+// Wired by Lab Overview StatsCard (LO-1). Backed by the per-author cache on
+// team_members (citation_count + h_index + last_scholar_refresh) which a
+// PB-side weekly cron refreshes via PUT /api/team/:slug. See
+// scripts/citations-scholar-stub.md for the cron design.
+//
+// staleTime is 1h to match the server-side Cache-Control: max-age=3600 on
+// /api/citations. refetchOnWindowFocus stays default (true) so users who
+// idle on the page still get a fresh number when they come back.
+export function useCitations(options?: { enabled?: boolean }) {
+  return useQuery({
+    queryKey: ['citations'],
+    queryFn: async () => {
+      try {
+        const res = await fetchCitations()
+        return res.data
+      } catch {
+        return null
+      }
+    },
+    staleTime: 60 * 60 * 1000, // 1 hour — matches server edge-cache TTL.
+    retry: false,
+    enabled: options?.enabled ?? true,
   })
 }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -79,6 +79,13 @@ interface Stats {
   featuredPublicationCount: number
 }
 
+export interface Citations {
+  total: number
+  last_refresh: string | null
+  members_with_data: number
+  members_total: number
+}
+
 export interface TaskRow {
   id: string
   meeting_id: string | null
@@ -244,6 +251,10 @@ export function fetchGrants() {
 
 export function fetchStats() {
   return fetchApi<Stats>('/api/stats')
+}
+
+export function fetchCitations() {
+  return fetchApi<Citations>('/api/citations')
 }
 
 // ── Write endpoints (require auth) ──────────────────────────


### PR DESCRIPTION
Wave 2 of audit/2026-04-28 fix phase. Hub-side citations infrastructure for LO-1. Per Decision D2-followup: per-author Google Scholar via `scholarly` Python library, weekly cron.

## What ships

### Schema v54 (Nick deploys manually)
`api/schema-v54-team-citations.sql`:
```sql
ALTER TABLE team_members ADD COLUMN citation_count INTEGER DEFAULT NULL;
ALTER TABLE team_members ADD COLUMN h_index INTEGER DEFAULT NULL;
ALTER TABLE team_members ADD COLUMN last_scholar_refresh TIMESTAMP DEFAULT NULL;
```
Deploy: `npx wrangler d1 execute mnccore-lab --remote --file=api/schema-v54-team-citations.sql`

### `GET /api/citations` endpoint
`api/routes/citations.ts`. Returns:
- `total` — SUM(team_members.citation_count) WHERE NOT NULL
- `last_refresh` — MAX(team_members.last_scholar_refresh)
- `members_with_data` — count of rows where citation_count IS NOT NULL
- `members_total` — total team_members count (for stale signal)
- Cache: `public, max-age=3600, s-maxage=3600` (1h)

### Frontend wire
`src/hooks/useApiData.ts` adds `useCitations()` hook (queryKey `['citations']`, staleTime 1h, refetch on focus).

`src/components/dashboard/StatsCard.tsx`:
- Drops hardcoded `const totalCitations = 2626`
- Wires `useCitations()`
- Loading state → `...`; no-data → `—` w/ tooltip; stale > 14d → "Updated N weeks ago" subtitle

### `PUT /api/team/:slug` extension
Original handler hardcoded `SELF_EDIT_FIELDS` + `ADMIN_ONLY_FIELDS` only and rejected non-JWT writes (401 for anonymous user). The PB cron uses Bearer PB_API_KEY auth which has no JWT identity.

Extended handler with `CITATION_FIELDS` bucket + `apiKeyAuth: boolean` parameter:
- When the API-key middleware sets `apiKeyValid === true`, the route forwards that flag
- Handler takes a separate code path that allows `CITATION_FIELDS`-only writes without owner/PI gates
- Browser users (even PI) get a 403 if they try to set citation fields by hand
- Activity log skipped for cron path so weekly runs don't spam 19 mechanical rows

### PB scholarly cron stub doc
`scripts/citations-scholar-stub.md` — weekly Python cron design for Nick to implement on PB infra. Iterates `team_members WHERE scholar_id IS NOT NULL`, scrapes scholar.google.com via `scholarly` library, writes back via `PUT /api/team/:slug` with `X-API-Key`. Includes Python snippet + auth header pattern + scholarly-blocked fallback notes.

## Patterns matched (no invention)
- Hook shape mirrors `useTeam()` / `useGrants()` (queryKey, queryFn, staleTime, retry: false, enabled flag)
- Cache-Control pattern from `api/routes/insights.ts:421`
- Schema migration comment style + cross-repo coordination note matches v52 + v53
- Auto-discovered by `scripts/local-db-bootstrap.ts` (no registry update needed)

## Verification
- `npm run build` clean (TypeScript + Vite) at every commit
- LO-1 verified STILL BROKEN against current source before fixing
- Build green at HEAD

## Closes
LO-1 (StatsCard.totalCitations = 2626 hardcoded constant on team-facing dashboard)