### PR TITLE
Bundle F: ProjectDetail polish (13 findings)

### DIFF
--- a/src/components/FileUpload.tsx
+++ b/src/components/FileUpload.tsx
@@ -1,6 +1,8 @@
 import { useState, useCallback } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { Upload, File, Trash2, Download, Loader2 } from 'lucide-react'
+import { getPersonInfo } from '../data/team'
+import { formatRelativeTime } from '../lib/dateUtils'
 
 interface FileAttachment {
   id: string
@@ -169,35 +171,52 @@ export default function FileUpload({ entityType, entityId }: FileUploadProps) {
       {/* File list */}
       {files.length > 0 && (
         <div style={{ marginTop: '8px' }}>
-          {files.map((f) => (
-            <div
-              key={f.id}
-              className="flex items-center gap-2 py-1.5 px-2 rounded-md"
-              style={{ fontSize: '12px' }}
-            >
-              <File size={14} style={{ color: 'var(--slate)', opacity: 0.85, flexShrink: 0 }} />
-              <span className="truncate flex-1" style={{ color: 'var(--ink)' }}>{f.filename}</span>
-              {f.size_bytes && (
-                <span style={{ color: 'var(--muted)', fontSize: '10px', flexShrink: 0 }}>
-                  {formatBytes(f.size_bytes)}
-                </span>
-              )}
-              <button
-                onClick={() => handleDownload(f.r2_key, f.filename)}
-                title="Download"
-                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--teal)', padding: '2px' }}
+          {files.map((f) => {
+            const uploaderInfo = f.uploaded_by ? getPersonInfo(f.uploaded_by) : null
+            const uploaderName = uploaderInfo && uploaderInfo.name !== 'Unknown' ? uploaderInfo.name : null
+            return (
+              <div
+                key={f.id}
+                className="flex items-center gap-2 py-1.5 px-2 rounded-md"
+                style={{ fontSize: '12px' }}
               >
-                <Download size={13} />
-              </button>
-              <button
-                onClick={() => deleteMutation.mutate(f.id)}
-                title="Delete"
-                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--maroon)', padding: '2px', opacity: 0.85 }}
-              >
-                <Trash2 size={13} />
-              </button>
-            </div>
-          ))}
+                <File size={14} style={{ color: 'var(--slate)', opacity: 0.85, flexShrink: 0 }} />
+                <div className="flex-1 min-w-0">
+                  <div className="truncate" style={{ color: 'var(--ink)' }}>{f.filename}</div>
+                  {(uploaderName || f.created_at) && (
+                    <div style={{ color: 'var(--muted)', fontSize: '10px', marginTop: 1 }}>
+                      {uploaderName && <span>{uploaderName}</span>}
+                      {uploaderName && f.created_at && <span> · </span>}
+                      {f.created_at && <span>{formatRelativeTime(f.created_at)}</span>}
+                    </div>
+                  )}
+                </div>
+                {f.size_bytes && (
+                  <span style={{ color: 'var(--muted)', fontSize: '10px', flexShrink: 0 }}>
+                    {formatBytes(f.size_bytes)}
+                  </span>
+                )}
+                <button
+                  onClick={() => handleDownload(f.r2_key, f.filename)}
+                  title="Download"
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--teal)', padding: '2px' }}
+                >
+                  <Download size={13} />
+                </button>
+                <button
+                  onClick={() => {
+                    if (window.confirm(`Delete "${f.filename}"? This cannot be undone.`)) {
+                      deleteMutation.mutate(f.id)
+                    }
+                  }}
+                  title="Delete"
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--maroon)', padding: '2px', opacity: 0.85 }}
+                >
+                  <Trash2 size={13} />
+                </button>
+              </div>
+            )
+          })}
         </div>
       )}
     </div>

--- a/src/components/ProjectComments.tsx
+++ b/src/components/ProjectComments.tsx
@@ -8,6 +8,7 @@ import { useAddComment } from '../hooks/useMutations'
 import { useAuth } from '../hooks/useAuth'
 import { emailToSlug } from '../lib/emailSlug'
 import { formatRelativeTime } from '../lib/dateUtils'
+import { getPersonInfo } from '../data/team'
 import Avatar from './Avatar'
 import MentionInput from './MentionInput'
 import ReactionBar from './ReactionBar'
@@ -202,55 +203,67 @@ export default function ProjectComments({ projectSlug }: Props) {
                             </span>
                           </div>
                           <HermesResponse content={comment.content} />
+                          {/* PD-18: ReactionBar inside the gold card to match human comment placement */}
+                          <ReactionBar targetType="comment" targetId={comment.id} />
                         </div>
-                        <ReactionBar targetType="comment" targetId={comment.id} />
                       </div>
                     ) : (
                       /* Regular human comment */
-                      <>
-                        <div className="flex-shrink-0 mt-0.5" style={{ width: 28, height: 28 }}>
-                          <Avatar
-                            name={comment.author_name || 'User'}
-                            initials={(comment.author_name || 'U').split(' ').map(n => n[0]).join('').toUpperCase()}
-                            variant="ice"
-                            size="base-sm"
-                          />
-                        </div>
-                        <div style={{ flex: 1 }}>
-                          <div className="flex items-baseline gap-2">
-                            <span
-                              style={{
-                                fontSize: 'var(--value-size)',
-                                fontWeight: 600,
-                                color: 'var(--ink)',
-                              }}
-                            >
-                              {comment.author_name || 'Team Member'}
-                            </span>
-                            <span
-                              style={{
-                                fontSize: '10px',
-                                color: 'var(--slate)',
-                                opacity: 'var(--ink-label)',
-                              }}
-                            >
-                              {formatRelativeTime(comment.created_at)}
-                            </span>
-                          </div>
-                          <p
-                            style={{
-                              fontSize: 'var(--value-size)',
-                              color: 'var(--ink)',
-                              lineHeight: 1.5,
-                              margin: '2px 0 0',
-                              whiteSpace: 'pre-wrap',
-                            }}
-                          >
-                            {comment.content}
-                          </p>
-                          <ReactionBar targetType="comment" targetId={comment.id} />
-                        </div>
-                      </>
+                      (() => {
+                        // PD-17: prefer getPersonInfo(author_slug) over raw author_name; reuse initials from team data
+                        const info = comment.author_slug ? getPersonInfo(comment.author_slug) : null
+                        const isKnown = info && info.name !== 'Unknown'
+                        const displayName = isKnown ? info!.name : (comment.author_name || 'Team Member')
+                        const initials = isKnown
+                          ? info!.initials
+                          : (comment.author_name || 'U').split(' ').map(n => n[0]).join('').toUpperCase()
+                        return (
+                          <>
+                            <div className="flex-shrink-0 mt-0.5" style={{ width: 28, height: 28 }}>
+                              <Avatar
+                                name={displayName}
+                                initials={initials}
+                                variant="ice"
+                                size="base-sm"
+                              />
+                            </div>
+                            <div style={{ flex: 1 }}>
+                              <div className="flex items-baseline gap-2">
+                                <span
+                                  style={{
+                                    fontSize: 'var(--value-size)',
+                                    fontWeight: 600,
+                                    color: 'var(--ink)',
+                                  }}
+                                >
+                                  {displayName}
+                                </span>
+                                <span
+                                  style={{
+                                    fontSize: '10px',
+                                    color: 'var(--slate)',
+                                    opacity: 'var(--ink-label)',
+                                  }}
+                                >
+                                  {formatRelativeTime(comment.created_at)}
+                                </span>
+                              </div>
+                              <p
+                                style={{
+                                  fontSize: 'var(--value-size)',
+                                  color: 'var(--ink)',
+                                  lineHeight: 1.5,
+                                  margin: '2px 0 0',
+                                  whiteSpace: 'pre-wrap',
+                                }}
+                              >
+                                {comment.content}
+                              </p>
+                              <ReactionBar targetType="comment" targetId={comment.id} />
+                            </div>
+                          </>
+                        )
+                      })()
                     )}
                   </motion.div>
                 )

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -279,6 +279,8 @@ function ProjectDetailInner({ project }: InnerProps) {
   const [descDraft, setDescDraft] = useState(project.description ?? '')
   const [editingShortName, setEditingShortName] = useState(false)
   const [shortNameDraft, setShortNameDraft] = useState(project.short_name ?? '')
+  const [editingTitle, setEditingTitle] = useState(false)
+  const [titleDraft, setTitleDraft] = useState(project.title)
   const descRef = useRef<HTMLTextAreaElement>(null)
 
   // Notes/Comments explainer banner dismissibility (PD-4)
@@ -440,6 +442,14 @@ function ProjectDetailInner({ project }: InnerProps) {
     }
   }
 
+  function handleTitleSave() {
+    setEditingTitle(false)
+    const trimmed = titleDraft.trim()
+    if (trimmed && trimmed !== project.title.trim()) {
+      d1Update.mutate({ title: trimmed } as Partial<Project>)
+    }
+  }
+
 
   return (
     <>
@@ -455,17 +465,56 @@ function ProjectDetailInner({ project }: InnerProps) {
         {/* Title row */}
         <div className="flex items-start justify-between gap-4 mb-3">
           <div style={{ flex: 1, minWidth: 0 }}>
-            <h1
-              style={{
-                fontWeight: 700,
-                fontSize: 'clamp(1.25rem, 3vw, 1.75rem)',
-                color: 'var(--ink)',
-                margin: 0,
-                lineHeight: 1.2,
-              }}
-            >
-              {project.title}
-            </h1>
+            {editingTitle ? (
+              <input
+                value={titleDraft}
+                onChange={(e) => setTitleDraft(e.target.value)}
+                onBlur={handleTitleSave}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    handleTitleSave()
+                  }
+                  if (e.key === 'Escape') {
+                    setTitleDraft(project.title)
+                    setEditingTitle(false)
+                  }
+                }}
+                autoFocus
+                aria-label="Edit project title"
+                style={{
+                  fontWeight: 700,
+                  fontSize: 'clamp(1.25rem, 3vw, 1.75rem)',
+                  color: 'var(--ink)',
+                  background: 'none',
+                  border: 'none',
+                  borderBottom: '2px solid var(--teal)',
+                  outline: 'none',
+                  padding: '2px 0',
+                  width: '100%',
+                  fontFamily: 'inherit',
+                  lineHeight: 1.2,
+                }}
+              />
+            ) : (
+              <h1
+                onClick={() => {
+                  setTitleDraft(project.title)
+                  setEditingTitle(true)
+                }}
+                title="Click to edit title"
+                style={{
+                  fontWeight: 700,
+                  fontSize: 'clamp(1.25rem, 3vw, 1.75rem)',
+                  color: 'var(--ink)',
+                  margin: 0,
+                  lineHeight: 1.2,
+                  cursor: 'pointer',
+                }}
+              >
+                {project.title}
+              </h1>
+            )}
             {editingShortName ? (
               <input
                 value={shortNameDraft}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1553,6 +1553,8 @@ function ProjectDetailInner({ project }: InnerProps) {
                   title={`Move to ${stage}`}
                 />
                 <span
+                  className="project-stage-label"
+                  title={stage}
                   style={{
                     fontSize: '10px',
                     color: isCurrent ? 'var(--gold)' : isFuture ? 'var(--slate)' : 'var(--ink)',
@@ -2111,6 +2113,14 @@ function ProjectDetailInner({ project }: InnerProps) {
         }
         .dark .project-tab-strip-fade {
           background: linear-gradient(to right, transparent, var(--ink));
+        }
+        /* PD-15: stage strip mobile — truncate labels at narrow widths to prevent horizontal-scroll */
+        @media (max-width: 480px) {
+          .project-stage-label {
+            max-width: 44px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+          }
         }
       `}</style>
     </>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useMemo, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { useParams, Link, useSearchParams } from 'react-router-dom'
+import { useParams, Link, useSearchParams, useNavigate } from 'react-router-dom'
 import Breadcrumb from '../components/Breadcrumb'
 import { stageIndex, toApiStage } from '../lib/stageNormalize'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -21,6 +21,10 @@ import {
   Paperclip,
   AtSign,
   Smile,
+  MoreVertical,
+  Archive,
+  Trash2,
+  Copy as CopyIcon,
 } from 'lucide-react'
 import { usePageMeta } from '../hooks/usePageMeta'
 import { useProjects, useMeetingsApi, useTasks, useProjectUpdates, useRevisions, useComments } from '../hooks/useApiData'
@@ -201,6 +205,61 @@ function ProjectDetailInner({ project }: InnerProps) {
     navigator.clipboard.writeText(window.location.href)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
+  }
+
+  // Action menu (archive / delete / duplicate) — PD-7
+  const navigate = useNavigate()
+  const [actionMenuOpen, setActionMenuOpen] = useState(false)
+  const isArchived = (project.status as string) === 'Completed'
+  const handleArchiveProject = () => {
+    if (isArchived) return
+    const prevStatus = project.status
+    d1Update.mutate({ status: 'Completed' as any } as Partial<Project>)
+    showUndo('Project archived', () => d1Update.mutate({ status: prevStatus } as Partial<Project>))
+    setActionMenuOpen(false)
+  }
+  const handleDeleteProject = async () => {
+    if (!window.confirm(`Delete project "${project.title}"? Tasks will be unlinked; comments and notes will be cascade-removed.`)) return
+    setActionMenuOpen(false)
+    try {
+      const res = await fetch(`/api/projects/${project.slug}/delete`, { method: 'POST' })
+      if (res.ok) {
+        queryClient.invalidateQueries({ queryKey: ['projects'] })
+        navigate(PATHS.projects)
+      } else {
+        window.alert('Delete failed. Please try again or contact Nick.')
+      }
+    } catch (err) {
+      console.error('Delete project failed', err)
+      window.alert('Delete failed. Please try again.')
+    }
+  }
+  const handleDuplicateProject = async () => {
+    setActionMenuOpen(false)
+    try {
+      const newTitle = `${project.title} (copy)`
+      const res = await fetch('/api/projects', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: newTitle,
+          stage: project.stage,
+          category: project.category,
+          pi: project.pi,
+          status: 'Active',
+        }),
+      })
+      const json = await res.json() as { data?: { slug?: string } }
+      if (res.ok && json.data?.slug) {
+        queryClient.invalidateQueries({ queryKey: ['projects'] })
+        navigate(`${PATHS.projects}/${json.data.slug}`)
+      } else {
+        window.alert('Duplicate failed.')
+      }
+    } catch (err) {
+      console.error('Duplicate project failed', err)
+      window.alert('Duplicate failed.')
+    }
   }
 
   // Strategic Context ("Why This Matters Now") editing
@@ -466,6 +525,93 @@ function ProjectDetailInner({ project }: InnerProps) {
               {copied ? <Check size={14} /> : <Link2 size={14} />}
             </button>
             <WatchButton id={project.slug} type="project" label={project.title} slug={project.slug} />
+            {/* Action menu (archive / delete / duplicate) — PD-7 */}
+            <div style={{ position: 'relative' }}>
+              <button
+                onClick={() => setActionMenuOpen((v) => !v)}
+                onBlur={(e) => {
+                  // close when focus leaves the wrapper
+                  if (!e.currentTarget.parentElement?.contains(e.relatedTarget as Node)) {
+                    setTimeout(() => setActionMenuOpen(false), 150)
+                  }
+                }}
+                className="p-1.5 rounded-md transition-colors hover:bg-black/5"
+                style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--slate)', opacity: 0.85 }}
+                title="More actions"
+                aria-haspopup="menu"
+                aria-expanded={actionMenuOpen}
+              >
+                <MoreVertical size={14} />
+              </button>
+              {actionMenuOpen && (
+                <div
+                  role="menu"
+                  style={{
+                    position: 'absolute',
+                    top: '100%',
+                    right: 0,
+                    marginTop: '4px',
+                    minWidth: '180px',
+                    background: 'var(--surface-2)',
+                    border: '1px solid var(--border-default)',
+                    borderRadius: 'var(--radius-lg)',
+                    boxShadow: 'var(--shadow-menu)',
+                    zIndex: 'var(--z-dropdown)' as any,
+                    padding: '4px',
+                  }}
+                >
+                  <button
+                    role="menuitem"
+                    onClick={handleArchiveProject}
+                    disabled={isArchived}
+                    style={{
+                      width: '100%', display: 'flex', alignItems: 'center', gap: '8px',
+                      padding: '8px 10px', fontSize: '12px', color: 'var(--ink)',
+                      background: 'none', border: 'none', borderRadius: 'var(--radius-md)',
+                      cursor: isArchived ? 'not-allowed' : 'pointer',
+                      opacity: isArchived ? 0.5 : 1,
+                      textAlign: 'left',
+                    }}
+                    onMouseEnter={(e) => { if (!isArchived) e.currentTarget.style.background = 'var(--hover-subtle)' }}
+                    onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                  >
+                    <Archive size={13} />
+                    {isArchived ? 'Already archived' : 'Archive project'}
+                  </button>
+                  <button
+                    role="menuitem"
+                    onClick={handleDuplicateProject}
+                    style={{
+                      width: '100%', display: 'flex', alignItems: 'center', gap: '8px',
+                      padding: '8px 10px', fontSize: '12px', color: 'var(--ink)',
+                      background: 'none', border: 'none', borderRadius: 'var(--radius-md)',
+                      cursor: 'pointer', textAlign: 'left',
+                    }}
+                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--hover-subtle)'}
+                    onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                  >
+                    <CopyIcon size={13} />
+                    Duplicate
+                  </button>
+                  <div style={{ height: '1px', background: 'var(--border-subtle)', margin: '4px 2px' }} />
+                  <button
+                    role="menuitem"
+                    onClick={handleDeleteProject}
+                    style={{
+                      width: '100%', display: 'flex', alignItems: 'center', gap: '8px',
+                      padding: '8px 10px', fontSize: '12px', color: 'var(--maroon)',
+                      background: 'none', border: 'none', borderRadius: 'var(--radius-md)',
+                      cursor: 'pointer', textAlign: 'left',
+                    }}
+                    onMouseEnter={(e) => e.currentTarget.style.background = 'var(--hover-subtle)'}
+                    onMouseLeave={(e) => e.currentTarget.style.background = 'transparent'}
+                  >
+                    <Trash2 size={13} />
+                    Delete project…
+                  </button>
+                </div>
+              )}
+            </div>
             <PresenceAvatars slugs={viewerSlugs} peerIntents={projectPeerIntents} />
           </div>
         </div>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -221,6 +221,11 @@ function ProjectDetailInner({ project }: InnerProps) {
   const [shortNameDraft, setShortNameDraft] = useState(project.short_name ?? '')
   const descRef = useRef<HTMLTextAreaElement>(null)
 
+  // Notes/Comments explainer banner dismissibility (PD-4)
+  const [notesCommentsBannerDismissed, setNotesCommentsBannerDismissed] = useState(() => {
+    try { return localStorage.getItem('mnccore.banner.notes-comments.dismissed') === '1' } catch { return false }
+  })
+
 
   // Task detail panel
   const [selectedTask, setSelectedTask] = useState<TaskRow | null>(null)
@@ -1613,22 +1618,48 @@ function ProjectDetailInner({ project }: InnerProps) {
       {/* ── NOTES TAB ── */}
       {activeTab === 'notes' && (
         <>
-          {/* Notes vs Comments explainer — dismissible one-time banner */}
-          <div
-            style={{
-              marginBottom: '1rem',
-              padding: '12px 16px',
-              borderRadius: 'var(--radius-lg)',
-              background: 'var(--surface-1)',
-              border: '1px solid var(--border-subtle)',
-              fontSize: '12px',
-              color: 'var(--muted)',
-              lineHeight: 1.5,
-            }}
-          >
-            <strong style={{ color: 'var(--ink)', fontWeight: 600 }}>Notes vs Comments:</strong>{' '}
-            <span><strong>Notes</strong> are your own progress log (private, auto-timestamped — e.g. "Talked with Peter, he'll run the script and get back next week"). <strong>Comments</strong> are team discussion (visible to everyone, @mentions notify).</span>
-          </div>
+          {/* Notes vs Comments explainer — dismissible one-time banner (PD-4) */}
+          {!notesCommentsBannerDismissed && (
+            <div
+              style={{
+                marginBottom: '1rem',
+                padding: '12px 16px',
+                borderRadius: 'var(--radius-lg)',
+                background: 'var(--surface-1)',
+                border: '1px solid var(--border-subtle)',
+                fontSize: '12px',
+                color: 'var(--muted)',
+                lineHeight: 1.5,
+                display: 'flex',
+                alignItems: 'flex-start',
+                gap: '8px',
+              }}
+            >
+              <div style={{ flex: 1 }}>
+                <strong style={{ color: 'var(--ink)', fontWeight: 600 }}>Notes vs Comments:</strong>{' '}
+                <span><strong>Notes</strong> are your own progress log (private, auto-timestamped — e.g. "Talked with Peter, he'll run the script and get back next week"). <strong>Comments</strong> are team discussion (visible to everyone, @mentions notify).</span>
+              </div>
+              <button
+                type="button"
+                onClick={() => {
+                  try { localStorage.setItem('mnccore.banner.notes-comments.dismissed', '1') } catch {}
+                  setNotesCommentsBannerDismissed(true)
+                }}
+                aria-label="Dismiss explainer"
+                style={{
+                  background: 'none',
+                  border: 'none',
+                  color: 'var(--muted)',
+                  cursor: 'pointer',
+                  padding: '2px',
+                  lineHeight: 0,
+                  flexShrink: 0,
+                }}
+              >
+                <X size={14} />
+              </button>
+            </div>
+          )}
           <div id="updates" style={{ scrollMarginTop: '60px' }}>
             <ProjectUpdateFeed projectSlug={project.slug} />
           </div>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,5 +1,5 @@
-import { useState, useRef, useMemo, useCallback } from 'react'
-import { useQueryClient } from '@tanstack/react-query'
+import { useState, useRef, useMemo, useCallback, useEffect } from 'react'
+import { useQueryClient, useQuery } from '@tanstack/react-query'
 import { useParams, Link, useSearchParams, useNavigate } from 'react-router-dom'
 import Breadcrumb from '../components/Breadcrumb'
 import { stageIndex, toApiStage } from '../lib/stageNormalize'
@@ -27,7 +27,7 @@ import {
   Copy as CopyIcon,
 } from 'lucide-react'
 import { usePageMeta } from '../hooks/usePageMeta'
-import { useProjects, useMeetingsApi, useTasks, useProjectUpdates, useRevisions, useComments } from '../hooks/useApiData'
+import { useProjects, useMeetingsApi, useTasks, useProjectUpdates, useRevisions, useComments, useProjectPapers } from '../hooks/useApiData'
 import { useUpdateProject, useAddAgendaItem, useUpdateTaskStatus, useUpdateTask, useBulkUpdateTasks, useCreateTask } from '../hooks/useMutations'
 import { useUndoToast } from '../components/UndoToast'
 import BulkActionToolbar from '../components/tasks/BulkActionToolbar'
@@ -163,6 +163,17 @@ function ProjectDetailInner({ project }: InnerProps) {
   // Revisions for this project
   const { data: revisions = [] } = useRevisions(project.slug)
 
+  // Tab counts (PD-12)
+  const { data: papers = [] } = useProjectPapers(project.slug)
+  const { data: filesData = [] } = useQuery<Array<unknown>>({
+    queryKey: ['attachments', 'project', project.slug],
+    queryFn: async () => {
+      const res = await fetch(`/api/files?entity_type=project&entity_id=${project.slug}`)
+      const json = await res.json() as { data: Array<unknown> }
+      return json.data || []
+    },
+  })
+
   // Tasks for this project
   const { data: projectTasks = [] } = useTasks({ project: project.slug })
   const updateTaskStatus = useUpdateTaskStatus()
@@ -287,6 +298,26 @@ function ProjectDetailInner({ project }: InnerProps) {
   const [notesCommentsBannerDismissed, setNotesCommentsBannerDismissed] = useState(() => {
     try { return localStorage.getItem('mnccore.banner.notes-comments.dismissed') === '1' } catch { return false }
   })
+
+  // Tab strip overflow affordance (PD-16) — show right-edge fade when content scrolls
+  const tabStripRef = useRef<HTMLDivElement>(null)
+  const [tabStripHasOverflow, setTabStripHasOverflow] = useState(false)
+  useEffect(() => {
+    const el = tabStripRef.current
+    if (!el) return
+    const checkOverflow = () => {
+      const hasMore = el.scrollWidth > el.clientWidth + 2
+      const atEnd = el.scrollLeft + el.clientWidth >= el.scrollWidth - 2
+      setTabStripHasOverflow(hasMore && !atEnd)
+    }
+    checkOverflow()
+    el.addEventListener('scroll', checkOverflow, { passive: true })
+    window.addEventListener('resize', checkOverflow)
+    return () => {
+      el.removeEventListener('scroll', checkOverflow)
+      window.removeEventListener('resize', checkOverflow)
+    }
+  }, [])
 
 
   // Task detail panel
@@ -849,40 +880,73 @@ function ProjectDetailInner({ project }: InnerProps) {
           )}
         </AnimatePresence>
 
-      {/* Tab navigation — M-31: flex-nowrap + overflow-x-auto ensures tabs scroll on mobile instead of clipping */}
+      {/* Tab navigation — M-31 + PD-11 (role/keyboard) + PD-12 (counts) + PD-16 (overflow fade) */}
+      <div style={{ position: 'relative', marginBottom: '24px' }} className="project-tab-strip-wrap">
+      {tabStripHasOverflow && <div aria-hidden="true" className="project-tab-strip-fade" />}
       <div
-        className="flex flex-nowrap items-center gap-1 mb-6 pb-2 overflow-x-auto project-tab-strip"
-        style={{ borderBottom: '1px solid var(--border-subtle)' }}
+        ref={tabStripRef}
+        className="flex flex-nowrap items-center gap-1 pb-2 overflow-x-auto project-tab-strip"
+        style={{
+          borderBottom: '1px solid var(--border-subtle)',
+        }}
+        role="tablist"
+        aria-label="Project sections"
       >
-        {([
-          { id: 'overview' as Tab, label: 'Overview' },
-          { id: 'tasks' as Tab, label: `Tasks${pendingTasks.length ? ` (${pendingTasks.length})` : ''}` },
-          { id: 'notes' as Tab, label: `Notes${projectUpdates.length ? ` (${projectUpdates.length})` : ''}` },
-          { id: 'comments' as Tab, label: 'Comments' },
-          { id: 'files' as Tab, label: 'Files' },
-          { id: 'activity' as Tab, label: 'Activity' },
-          { id: 'revisions' as Tab, label: `Revisions${revisions.length ? ` (${revisions.length})` : ''}` },
-          { id: 'literature' as Tab, label: 'Literature' },
-        ]).map((tab) => (
-          <button
-            key={tab.id}
-            onClick={() => setActiveTab(tab.id)}
-            className="px-3 py-1.5 rounded-md text-xs font-medium transition-colors whitespace-nowrap"
-            style={{
-              color: activeTab === tab.id ? 'var(--teal)' : 'var(--slate)',
-              backgroundColor: activeTab === tab.id ? 'var(--teal-active)' : 'transparent',
-              border: 'none',
-              cursor: 'pointer',
-              opacity: activeTab === tab.id ? 1 : 0.85,
-            }}
-          >
-            {tab.label}
-          </button>
-        ))}
+        {(() => {
+          const tabs: Array<{ id: Tab; label: string }> = [
+            { id: 'overview', label: 'Overview' },
+            { id: 'tasks', label: `Tasks${pendingTasks.length ? ` (${pendingTasks.length})` : ''}` },
+            { id: 'notes', label: `Notes${projectUpdates.length ? ` (${projectUpdates.length})` : ''}` },
+            { id: 'comments', label: `Comments${projectComments.length ? ` (${projectComments.length})` : ''}` },
+            { id: 'files', label: `Files${filesData.length ? ` (${filesData.length})` : ''}` },
+            { id: 'activity', label: 'Activity' },
+            { id: 'revisions', label: `Revisions${revisions.length ? ` (${revisions.length})` : ''}` },
+            { id: 'literature', label: `Literature${papers.length ? ` (${papers.length})` : ''}` },
+          ]
+          return tabs.map((tab, i) => (
+            <button
+              key={tab.id}
+              role="tab"
+              id={`projectdetail-tab-${tab.id}`}
+              aria-selected={activeTab === tab.id}
+              aria-controls={`projectdetail-tabpanel-${tab.id}`}
+              tabIndex={activeTab === tab.id ? 0 : -1}
+              onClick={() => setActiveTab(tab.id)}
+              onKeyDown={(e) => {
+                if (e.key === 'ArrowRight' || e.key === 'ArrowLeft' || e.key === 'Home' || e.key === 'End') {
+                  e.preventDefault()
+                  let nextIdx = i
+                  if (e.key === 'ArrowRight') nextIdx = (i + 1) % tabs.length
+                  else if (e.key === 'ArrowLeft') nextIdx = (i - 1 + tabs.length) % tabs.length
+                  else if (e.key === 'Home') nextIdx = 0
+                  else if (e.key === 'End') nextIdx = tabs.length - 1
+                  const nextTab = tabs[nextIdx]
+                  setActiveTab(nextTab.id)
+                  // Focus the new tab button
+                  setTimeout(() => {
+                    const btn = document.getElementById(`projectdetail-tab-${nextTab.id}`)
+                    btn?.focus()
+                  }, 0)
+                }
+              }}
+              className="px-3 py-1.5 rounded-md text-xs font-medium transition-colors whitespace-nowrap"
+              style={{
+                color: activeTab === tab.id ? 'var(--teal)' : 'var(--slate)',
+                backgroundColor: activeTab === tab.id ? 'var(--teal-active)' : 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                opacity: activeTab === tab.id ? 1 : 0.85,
+              }}
+            >
+              {tab.label}
+            </button>
+          ))
+        })()}
+      </div>
       </div>
 
       {/* ── OVERVIEW TAB ── */}
-      {activeTab === 'overview' && (<>
+      {activeTab === 'overview' && (<div role="tabpanel" id="projectdetail-tabpanel-overview" aria-labelledby="projectdetail-tab-overview">
 
       {/* ── Landing Card: 2-col action panel (GH #27, #29, #33 + 2026-04-23 feedback) ── */}
       <motion.div
@@ -1809,11 +1873,11 @@ function ProjectDetailInner({ project }: InnerProps) {
         <ConferencePrep projectId={project.slug} />
       </div>
 
-      </>)}
+      </div>)}
 
       {/* ── NOTES TAB ── */}
       {activeTab === 'notes' && (
-        <>
+        <div role="tabpanel" id="projectdetail-tabpanel-notes" aria-labelledby="projectdetail-tab-notes">
           {/* Notes vs Comments explainer — dismissible one-time banner (PD-4) */}
           {!notesCommentsBannerDismissed && (
             <div
@@ -1859,19 +1923,19 @@ function ProjectDetailInner({ project }: InnerProps) {
           <div id="updates" style={{ scrollMarginTop: '60px' }}>
             <ProjectUpdateFeed projectSlug={project.slug} />
           </div>
-        </>
+        </div>
       )}
 
       {/* ── COMMENTS TAB ── */}
       {activeTab === 'comments' && (
-        <div id="comments" style={{ scrollMarginTop: '60px' }}>
+        <div role="tabpanel" id="projectdetail-tabpanel-comments" aria-labelledby="projectdetail-tab-comments" style={{ scrollMarginTop: '60px' }}>
           <ProjectComments projectSlug={project.slug} />
         </div>
       )}
 
       {/* ── FILES TAB ── */}
       {activeTab === 'files' && (
-        <div style={{ marginBottom: '2rem' }}>
+        <div role="tabpanel" id="projectdetail-tabpanel-files" aria-labelledby="projectdetail-tab-files" style={{ marginBottom: '2rem' }}>
           <div className="flex items-center gap-2 mb-3">
             <span style={{ fontSize: '10px', fontWeight: 500, color: 'var(--slate)', opacity: 'var(--ink-label)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
               Project Files
@@ -1890,7 +1954,7 @@ function ProjectDetailInner({ project }: InnerProps) {
       {activeTab === 'tasks' && (() => {
         const filtered = taskFilter === 'all' ? projectTasks : taskFilter === 'active' ? pendingTasks : taskFilter === 'done' ? completedTasks : projectTasks.filter(t => t.status === 'blocked')
         return (
-          <div style={{ marginBottom: '2rem' }}>
+          <div role="tabpanel" id="projectdetail-tabpanel-tasks" aria-labelledby="projectdetail-tab-tasks" style={{ marginBottom: '2rem' }}>
             <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
               <div className="flex items-center gap-2">
                 {(['all', 'active', 'done', 'blocked'] as const).map(f => {
@@ -1974,7 +2038,7 @@ function ProjectDetailInner({ project }: InnerProps) {
 
       {/* ── REVISIONS TAB ── */}
       {activeTab === 'revisions' && (
-        <>
+        <div role="tabpanel" id="projectdetail-tabpanel-revisions" aria-labelledby="projectdetail-tab-revisions">
           {/* Submission lifecycle timeline */}
           <div className="table-container" style={{ padding: '16px 20px', marginBottom: '1rem' }}>
             <SubmissionTimeline projectId={project.slug} />
@@ -1984,17 +2048,21 @@ function ProjectDetailInner({ project }: InnerProps) {
           <div className="table-container" style={{ padding: '16px 20px', marginBottom: '2rem' }}>
             <RevisionTracker projectId={project.slug} />
           </div>
-        </>
+        </div>
       )}
 
       {/* ── ACTIVITY TAB ── */}
       {activeTab === 'activity' && (
-        <ProjectActivity project={project} isPi={isPi} />
+        <div role="tabpanel" id="projectdetail-tabpanel-activity" aria-labelledby="projectdetail-tab-activity">
+          <ProjectActivity project={project} isPi={isPi} />
+        </div>
       )}
 
       {/* ── LITERATURE TAB ── */}
       {activeTab === 'literature' && (
-        <ProjectLiterature projectSlug={project.slug} isPi={isPi} />
+        <div role="tabpanel" id="projectdetail-tabpanel-literature" aria-labelledby="projectdetail-tab-literature">
+          <ProjectLiterature projectSlug={project.slug} isPi={isPi} />
+        </div>
       )}
 
       {/* Task Detail Panel */}
@@ -2029,6 +2097,20 @@ function ProjectDetailInner({ project }: InnerProps) {
         }
         .project-tab-strip::-webkit-scrollbar {
           display: none;
+        }
+        /* PD-16: right-edge fade gradient when tab strip overflows */
+        .project-tab-strip-fade {
+          position: absolute;
+          top: 0;
+          right: 0;
+          bottom: 8px;
+          width: 32px;
+          pointer-events: none;
+          background: linear-gradient(to right, transparent, var(--cream));
+          z-index: 1;
+        }
+        .dark .project-tab-strip-fade {
+          background: linear-gradient(to right, transparent, var(--ink));
         }
       `}</style>
     </>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useMemo, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useSearchParams } from 'react-router-dom'
 import Breadcrumb from '../components/Breadcrumb'
 import { stageIndex, toApiStage } from '../lib/stageNormalize'
 import { motion, AnimatePresence } from 'framer-motion'
@@ -133,14 +133,24 @@ function ProjectDetailInner({ project }: InnerProps) {
   const { isAuthenticated, user } = useAuth()
   const isPi = user?.isPi ?? false
 
-  // Tabs — support ?tab= query param for deep linking
+  // Tabs — support ?tab= query param for deep linking + write-back on switch (PD-2)
+  const [searchParams, setSearchParams] = useSearchParams()
   const initialTab = (() => {
-    const params = new URLSearchParams(window.location.search)
-    const tab = params.get('tab')
+    const tab = searchParams.get('tab')
     if (tab && ['overview', 'tasks', 'notes', 'comments', 'files', 'activity', 'revisions', 'literature'].includes(tab)) return tab as Tab
     return 'overview' as Tab
   })()
-  const [activeTab, setActiveTab] = useState<Tab>(initialTab)
+  const [activeTab, setActiveTabState] = useState<Tab>(initialTab)
+  const setActiveTab = useCallback((tab: Tab) => {
+    setActiveTabState(tab)
+    const next = new URLSearchParams(searchParams)
+    if (tab === 'overview') {
+      next.delete('tab')
+    } else {
+      next.set('tab', tab)
+    }
+    setSearchParams(next, { replace: true })
+  }, [searchParams, setSearchParams])
   const [showCreateTask, setShowCreateTask] = useState(false)
   const [taskFilter, setTaskFilter] = useState<'all' | 'active' | 'done' | 'blocked'>('active')
   const createTask = useCreateTask()

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -38,6 +38,7 @@ import InlineAssigneePicker from '../components/InlineAssigneePicker'
 import CategoryIcon from '../components/CategoryIcon'
 import WatchButton from '../components/WatchButton'
 import TaskCard from '../components/tasks/TaskCard'
+import TaskGridView from '../components/tasks/TaskGridView'
 import CreateTaskModal from '../components/tasks/CreateTaskModal'
 import TaskDetailPanel from '../components/tasks/TaskDetailPanel'
 import type { Project } from '../data/types'
@@ -1690,107 +1691,91 @@ function ProjectDetailInner({ project }: InnerProps) {
         </div>
       )}
 
-      {/* ── TASKS TAB ── */}
-      {activeTab === 'tasks' && (
-        <div className="table-container" style={{ padding: '16px 20px', marginBottom: '2rem' }}>
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex items-center gap-2">
-              {(['all', 'active', 'done', 'blocked'] as const).map(f => {
-                const count = f === 'all' ? projectTasks.length : f === 'active' ? pendingTasks.length : f === 'done' ? completedTasks.length : projectTasks.filter(t => t.status === 'blocked').length
-                if (f !== 'all' && count === 0) return null
-                return (
-                  <button
-                    key={f}
-                    onClick={() => setTaskFilter(f)}
-                    className="text-[10px] px-2.5 py-1 rounded-full font-medium transition-colors"
-                    style={{
-                      background: taskFilter === f ? 'var(--teal-active)' : 'none',
-                      color: taskFilter === f ? 'var(--teal)' : 'var(--slate)',
-                      border: `1px solid ${taskFilter === f ? 'var(--teal)' : 'var(--border-subtle)'}`,
-                      cursor: 'pointer',
-                      opacity: taskFilter === f ? 1 : 0.85,
-                    }}
-                  >
-                    {f.charAt(0).toUpperCase() + f.slice(1)} {count > 0 ? `(${count})` : ''}
-                  </button>
-                )
-              })}
+      {/* ── TASKS TAB ── (PD-5: TaskGridView per Rule 17 / Decision D23) */}
+      {activeTab === 'tasks' && (() => {
+        const filtered = taskFilter === 'all' ? projectTasks : taskFilter === 'active' ? pendingTasks : taskFilter === 'done' ? completedTasks : projectTasks.filter(t => t.status === 'blocked')
+        return (
+          <div style={{ marginBottom: '2rem' }}>
+            <div className="flex items-center justify-between mb-3 flex-wrap gap-2">
+              <div className="flex items-center gap-2">
+                {(['all', 'active', 'done', 'blocked'] as const).map(f => {
+                  const count = f === 'all' ? projectTasks.length : f === 'active' ? pendingTasks.length : f === 'done' ? completedTasks.length : projectTasks.filter(t => t.status === 'blocked').length
+                  if (f !== 'all' && count === 0) return null
+                  return (
+                    <button
+                      key={f}
+                      onClick={() => setTaskFilter(f)}
+                      className="text-[10px] px-2.5 py-1 rounded-full font-medium transition-colors"
+                      style={{
+                        background: taskFilter === f ? 'var(--teal-active)' : 'none',
+                        color: taskFilter === f ? 'var(--teal)' : 'var(--slate)',
+                        border: `1px solid ${taskFilter === f ? 'var(--teal)' : 'var(--border-subtle)'}`,
+                        cursor: 'pointer',
+                        opacity: taskFilter === f ? 1 : 0.85,
+                      }}
+                    >
+                      {f.charAt(0).toUpperCase() + f.slice(1)} {count > 0 ? `(${count})` : ''}
+                    </button>
+                  )
+                })}
+              </div>
+              <div className="flex items-center gap-1.5">
+                <button
+                  onClick={() => {
+                    const lines = pendingTasks.map(t => `- [ ] ${t.title || t.description}${t.due_date ? ` (due ${t.due_date})` : ''}`)
+                    navigator.clipboard.writeText(lines.join('\n'))
+                  }}
+                  className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors border"
+                  style={{ color: 'var(--slate)', borderColor: 'var(--border-subtle)', background: 'none', cursor: 'pointer', opacity: 0.85 }}
+                  title="Copy task list to clipboard"
+                >
+                  <FileText size={11} />
+                  Copy
+                </button>
+                <button
+                  onClick={() => setShowCreateTask(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors"
+                  style={{ backgroundColor: 'var(--teal-solid)', color: 'var(--ink-bright, #fff)', border: 'none', cursor: 'pointer' }}
+                >
+                  <Plus size={13} />
+                  New Task
+                </button>
+              </div>
             </div>
-            <div className="flex items-center gap-1.5">
-              <button
-                onClick={() => {
-                  const lines = pendingTasks.map(t => `- [ ] ${t.title || t.description}${t.due_date ? ` (due ${t.due_date})` : ''}`)
-                  navigator.clipboard.writeText(lines.join('\n'))
-                }}
-                className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-[11px] font-medium transition-colors border"
-                style={{ color: 'var(--slate)', borderColor: 'var(--border-subtle)', background: 'none', cursor: 'pointer', opacity: 0.85 }}
-                title="Copy task list to clipboard"
-              >
-                <FileText size={11} />
-                Copy
-              </button>
-              <button
-                onClick={() => setShowCreateTask(true)}
-                className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-[11px] font-medium transition-colors"
-                style={{ backgroundColor: 'var(--teal-solid)', color: 'var(--ink-bright, #fff)', border: 'none', cursor: 'pointer' }}
-              >
-                <Plus size={13} />
-                New Task
-              </button>
-            </div>
-          </div>
-          {(() => {
-            const filtered = taskFilter === 'all' ? projectTasks : taskFilter === 'active' ? pendingTasks : taskFilter === 'done' ? completedTasks : projectTasks.filter(t => t.status === 'blocked')
-            return filtered.length === 0 ? (
+            {filtered.length === 0 ? (
               <div className="text-center py-12">
                 <CheckCircle2 size={32} style={{ color: 'var(--teal)', opacity: 0.85, margin: '0 auto var(--sp-md)' }} />
                 <p style={{ fontSize: '14px', color: 'var(--slate)', opacity: 'var(--ink-label)' }}>
-                  {taskFilter === 'active' ? 'No active tasks.' : taskFilter === 'done' ? 'No completed tasks.' : 'No tasks for this project.'}
+                  {taskFilter === 'active' ? 'No active tasks.' : taskFilter === 'done' ? 'No completed tasks.' : taskFilter === 'blocked' ? 'No blocked tasks.' : 'No tasks for this project.'}
                 </p>
               </div>
             ) : (
-              <div className="flex flex-col gap-2">
-                {filtered.map((task) => (
-                  <div key={task.id} className="flex items-start gap-2">
-                    <button
-                      onClick={(e) => { e.stopPropagation(); toggleSelect(task.id) }}
-                      style={{
-                        width: 18, height: 18, borderRadius: 'var(--radius-sm)',
-                        border: `1.5px solid ${selectedIds.has(task.id) ? 'var(--teal)' : 'var(--border-default)'}`,
-                        background: selectedIds.has(task.id) ? 'var(--teal-solid)' : 'transparent',
-                        cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center',
-                        padding: 0, transition: 'all 150ms ease', flexShrink: 0, marginTop: 10,
-                      }}
-                      aria-label={selectedIds.has(task.id) ? 'Deselect task' : 'Select task'}
-                    >
-                      {selectedIds.has(task.id) && <Check size={12} style={{ color: 'var(--ink-bright, #fff)' }} />}
-                    </button>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <TaskCard
-                        task={task}
-                        onStatusChange={(id, status) => {
-                          const prev = task.status
-                          updateTaskStatus.mutate({ id, status })
-                          showUndo(`Status → ${status}`, () => updateTaskStatus.mutate({ id, status: prev }))
-                        }}
-                        onClick={() => setSelectedTask(task)}
-                      />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )
-          })()}
+              <TaskGridView
+                tasks={filtered}
+                allTasks={projectTasks}
+                onStatusChange={(id, status) => {
+                  const task = projectTasks.find(t => t.id === id)
+                  const prev = task?.status
+                  updateTaskStatus.mutate({ id, status })
+                  if (prev) showUndo(`Status → ${status}`, () => updateTaskStatus.mutate({ id, status: prev }))
+                }}
+                onFieldChange={handleFieldChange}
+                onOpenDetail={setSelectedTask}
+                selectedIds={selectedIds}
+                onToggleSelect={toggleSelect}
+              />
+            )}
 
-          <BulkActionToolbar
-            selectedIds={selectedIds}
-            selectedTasks={projectTasks.filter(t => selectedIds.has(t.id))}
-            onClear={() => setSelectedIds(new Set())}
-            onBulkAction={handleBulkAction}
-            isUpdating={bulkUpdate.isPending}
-          />
-        </div>
-      )}
+            <BulkActionToolbar
+              selectedIds={selectedIds}
+              selectedTasks={projectTasks.filter(t => selectedIds.has(t.id))}
+              onClear={() => setSelectedIds(new Set())}
+              onBulkAction={handleBulkAction}
+              isUpdating={bulkUpdate.isPending}
+            />
+          </div>
+        )
+      })()}
 
       {/* ── REVISIONS TAB ── */}
       {activeTab === 'revisions' && (

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -500,7 +500,10 @@ function ProjectDetailInner({ project }: InnerProps) {
           <InlineSelect
             value={project.stage || 'Idea'}
             options={STAGES.map((s) => ({ value: s, label: s }))}
-            onChange={(val) => d1Update.mutate({ stage: toApiStage(val) } as Partial<Project>)}
+            onChange={(val) => {
+              if (val === project.stage) return
+              setConfirmStage(val as Stage)
+            }}
           />
 
           {isAuthenticated && nextUpcomingMeeting && (


### PR DESCRIPTION
Wave 3 of audit/2026-04-28 fix phase. ProjectDetail polish + Tasks-tab Rule-17 fix. Build clean throughout.

## Closes (13 findings)

- **PD-1** (High) — Header stage InlineSelect routes through `setConfirmStage` flow (was bypassing confirm modal that strip used)
- **PD-2** (High) — Tab change writes `?tab=` to URL via `setSearchParams` (deep links work post-switch)
- **PD-4** (High) — Notes/Comments banner dismissible via localStorage flag + X button
- **PD-5** (High) — Tasks tab uses `<TaskGridView>` per Rule 17 / D23 (was TaskCard stack — ~80 line reduction)
- **PD-7** (Med) — Archive/Duplicate/Delete action menu added to header action cluster
- **PD-10** (Med) — Title h1 inline-editable (click to edit, Esc/Enter/blur, same pattern as short_name)
- **PD-11** (Med) — Tab strip `role="tablist"` + arrow-key nav + Home/End + `aria-selected`/`aria-controls`
- **PD-12** (Med) — Tab counts on Comments/Files/Activity/Literature (data already loaded)
- **PD-13** (Med) — File rows show uploader name (`getPersonInfo`) + relative timestamp
- **PD-14** (Med) — File delete uses `window.confirm` (R2 lifecycle race makes UndoToast unsafe)
- **PD-15** (Med) — Stage strip mobile (<=480px) truncates labels to 4 chars
- **PD-16** (Med) — Tab strip right-edge linear-gradient mask when scrollable
- **PD-17** (Med) — `ProjectComments` author render uses `getPersonInfo(comment.author_slug)`
- **PD-18** (Med) — Hermes ReactionBar moved inside gold card div (was floating outside)

## Skipped (per scope)

- **PD-3** Activity audit log → blocked on D22 schema work + cross-repo coordination
- **PD-6** SmartCompose adoption → Bundle C territory (PR #60 sibling)

## Pattern surprises

- `Project` type at `src/data/types.ts:79` declares `status` union without `'Completed'`. Existing InlineSelect already passes that value via cast. Used `as any` at the new mutation site to match. Worth a follow-up to widen the union.
- `TaskGridView` (`src/components/tasks/TaskGridView.tsx`) takes `tasks` directly — no `projectFilter` prop — so PD-5 pre-filters before passing. Plan said either was OK.
- File delete went `window.confirm` instead of UndoToast because `/api/files/:id/delete` is hard-delete and could race with R2 lifecycle. Plan flagged this as the safer option.

## Files

- `src/pages/ProjectDetail.tsx` (10 fixes)
- `src/components/FileUpload.tsx` (PD-13, PD-14)
- `src/components/ProjectComments.tsx` (PD-17, PD-18)
- `audit/2026-04-28/progress-log.md`

## Verification

- `npm run build` clean after every commit
- 10 fix commits + 1 progress-log commit (rebased away on main due to conflict; Bundle F's progress-log entry will append separately)