### PR TITLE
Bundle C: SmartCompose universal sweep (D14, 9 sites)

### DIFF
--- a/src/components/ProjectComments.tsx
+++ b/src/components/ProjectComments.tsx
@@ -1,6 +1,5 @@
-import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { MessageSquare, Send } from 'lucide-react'
+import { MessageSquare } from 'lucide-react'
 import HermesMark from './HermesMark'
 import HermesResponse from './HermesResponse'
 import { useComments } from '../hooks/useApiData'
@@ -10,7 +9,7 @@ import { emailToSlug } from '../lib/emailSlug'
 import { formatRelativeTime } from '../lib/dateUtils'
 import { getPersonInfo } from '../data/team'
 import Avatar from './Avatar'
-import MentionInput from './MentionInput'
+import SmartCompose from './SmartCompose'
 import ReactionBar from './ReactionBar'
 import { useToast } from '../hooks/useToast'
 
@@ -23,21 +22,17 @@ export default function ProjectComments({ projectSlug }: Props) {
   const addComment = useAddComment(projectSlug)
   const { user, isAuthenticated } = useAuth()
   const { showSuccess } = useToast()
-  const [text, setText] = useState('')
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    const content = text.trim()
-    if (!content) return
-
-    addComment.mutate({
-      content,
-      author: emailToSlug(user?.email) || 'anonymous',
-    }, {
-      onSuccess: () => showSuccess('Comment posted'),
+  const handleSubmit = (content: string) =>
+    new Promise<void>((resolve) => {
+      addComment.mutate({
+        content,
+        author: emailToSlug(user?.email) || 'anonymous',
+      }, {
+        onSuccess: () => { showSuccess('Comment posted'); resolve() },
+        onError: () => resolve(),
+      })
     })
-    setText('')
-  }
 
   return (
     <motion.div
@@ -79,71 +74,26 @@ export default function ProjectComments({ projectSlug }: Props) {
         }}
         className="detail-card"
       >
-        {/* Comment input */}
-        <form onSubmit={handleSubmit} style={{ marginBottom: comments.length > 0 ? '16px' : 0 }}>
-          <div className="flex gap-2 items-end">
-            <MentionInput
-              value={text}
-              onChange={setText}
-              placeholder={isAuthenticated ? 'Add a comment... (use @mention to tag team)' : 'Sign in to comment'}
-              disabled={!isAuthenticated && import.meta.env.PROD}
+        {/* Comment input — SmartCompose (D14). */}
+        <div style={{ marginBottom: comments.length > 0 ? '16px' : 0 }}>
+          {!isAuthenticated && import.meta.env.PROD ? (
+            <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75 }}>
+              <a href="/api/auth/login" style={{ color: 'var(--teal)', fontWeight: 'var(--weight-ui)' as any, textDecoration: 'underline' }}>Sign in</a> to comment
+            </span>
+          ) : (
+            <SmartCompose
+              theme="light"
+              bare
+              onSubmit={handleSubmit}
+              submitting={addComment.isPending}
+              uploadContext={{ type: 'project', id: projectSlug }}
+              placeholder="Add a comment... (use @mention to tag team)"
               rows={2}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault()
-                  handleSubmit(e)
-                }
-              }}
-              style={{
-                width: '100%',
-                fontSize: 'var(--value-size)',
-                color: 'var(--ink)',
-                background: 'var(--cream)',
-                border: '1px solid rgba(201, 168, 76, 0.15)',
-                borderRadius: 'var(--radius-lg)',
-                padding: '10px 12px',
-                resize: 'none',
-                outline: 'none',
-                lineHeight: 1.5,
-                transition: 'border-color 0.2s',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--gold)')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = 'var(--gold-emphasis)')}
+              alwaysShowToolbar
+              submitLabel="Comment"
             />
-            {!isAuthenticated && import.meta.env.PROD && (
-              <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75 }}>
-                <a href="/api/auth/login" style={{ color: 'var(--teal)', fontWeight: 'var(--weight-ui)' as any, textDecoration: 'underline' }}>Sign in</a> to comment
-              </span>
-            )}
-            {text.trim() && (
-              <motion.button
-                type="submit"
-                initial={{ opacity: 0, scale: 0.8 }}
-                animate={{ opacity: 1, scale: 1 }}
-                className="cursor-pointer flex-shrink-0 p-2.5 rounded-lg"
-                style={{
-                  background: 'var(--gold)',
-                  color: '#0f1923',
-                  border: 'none',
-                }}
-                whileTap={{ scale: 0.9 }}
-                disabled={addComment.isPending}
-              >
-                <Send size={16} />
-              </motion.button>
-            )}
-          </div>
-          <p
-            style={{
-              fontSize: '10px',
-              color: 'var(--slate)',
-              opacity: 'var(--ink-hint)',
-              marginTop: '4px',
-            }}
-          >
-            Ctrl+Enter to send
-          </p>
-        </form>
+          )}
+        </div>
 
         {/* Comments list */}
         {isLoading ? (

--- a/src/components/ProjectUpdateFeed.tsx
+++ b/src/components/ProjectUpdateFeed.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import { MessageCircle, AlertTriangle, CheckCircle, HelpCircle, TrendingUp, Send } from 'lucide-react'
+import { MessageCircle, AlertTriangle, CheckCircle, HelpCircle, TrendingUp } from 'lucide-react'
 import { useProjectUpdates } from '../hooks/useApiData'
 import type { ProjectUpdateRow } from '../hooks/useApiData'
 import { usePostProjectUpdate } from '../hooks/useMutations'
@@ -8,7 +8,7 @@ import { useAuth } from '../hooks/useAuth'
 import { getPersonInfo } from '../data/team'
 import { formatRelativeTime } from '../lib/dateUtils'
 import Avatar from './Avatar'
-import MentionInput from './MentionInput'
+import SmartCompose from './SmartCompose'
 import ReactionBar from './ReactionBar'
 import { useToast } from '../hooks/useToast'
 
@@ -28,17 +28,15 @@ export default function ProjectUpdateFeed({ projectSlug }: Props) {
   const postUpdate = usePostProjectUpdate(projectSlug)
   const { isAuthenticated } = useAuth()
   const { showSuccess } = useToast()
-  const [text, setText] = useState('')
   const [updateType, setUpdateType] = useState<string>('progress')
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!text.trim()) return
-    postUpdate.mutate({ content: text.trim(), update_type: updateType }, {
-      onSuccess: () => showSuccess('Update posted'),
+  const handleSubmit = (content: string) =>
+    new Promise<void>((resolve) => {
+      postUpdate.mutate({ content, update_type: updateType }, {
+        onSuccess: () => { showSuccess('Update posted'); resolve() },
+        onError: () => resolve(),
+      })
     })
-    setText('')
-  }
 
   return (
     <motion.div
@@ -60,8 +58,8 @@ export default function ProjectUpdateFeed({ projectSlug }: Props) {
       </div>
 
       <div style={{ background: 'var(--ice)', borderRadius: 'var(--radius-xl)', padding: '16px 20px' }} className="detail-card">
-        {/* Post update form */}
-        <form onSubmit={handleSubmit} style={{ marginBottom: updates.length > 0 ? '16px' : 0 }}>
+        {/* Post update form — type pills row + SmartCompose (D14). */}
+        <div style={{ marginBottom: updates.length > 0 ? '16px' : 0 }}>
           {/* Type selector */}
           <div className="flex gap-1.5 mb-2">
             {Object.entries(TYPE_CONFIG).map(([key, config]) => {
@@ -89,42 +87,24 @@ export default function ProjectUpdateFeed({ projectSlug }: Props) {
             })}
           </div>
 
-          <div className="flex gap-2 items-end">
-            <MentionInput
-              value={text}
-              onChange={setText}
-              placeholder={isAuthenticated ? 'Post a note... (use @mention to tag team)' : 'Sign in to post notes'}
-              disabled={!isAuthenticated && import.meta.env.PROD}
-              rows={2}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault()
-                  handleSubmit(e)
-                }
-              }}
-              style={{
-                fontSize: 'var(--value-size)', color: 'var(--ink)',
-                background: 'var(--cream)', border: '1px solid rgba(201, 168, 76, 0.15)',
-                borderRadius: 'var(--radius-lg)', padding: '10px 12px', resize: 'none', outline: 'none',
-                lineHeight: 1.5, transition: 'border-color 0.2s', width: '100%',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--gold)')}
-              onBlur={(e) => (e.currentTarget.style.borderColor = 'var(--gold-emphasis)')}
-            />
-            {text.trim() && (
-              <motion.button type="submit" initial={{ opacity: 0, scale: 0.8 }} animate={{ opacity: 1, scale: 1 }}
-                className="cursor-pointer flex-shrink-0 p-2.5 rounded-lg"
-                style={{ background: 'var(--gold)', color: '#0f1923', border: 'none' }}>
-                <Send size={16} />
-              </motion.button>
-            )}
-          </div>
-          {!isAuthenticated && import.meta.env.PROD && (
+          {!isAuthenticated && import.meta.env.PROD ? (
             <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75, marginTop: '4px', display: 'inline-block' }}>
               <a href="/api/auth/login" style={{ color: 'var(--teal)', fontWeight: 'var(--weight-ui)' as any, textDecoration: 'underline' }}>Sign in</a> to post notes
             </span>
+          ) : (
+            <SmartCompose
+              theme="light"
+              bare
+              onSubmit={handleSubmit}
+              submitting={postUpdate.isPending}
+              uploadContext={{ type: 'project', id: projectSlug }}
+              placeholder="Post a note... (use @mention to tag team)"
+              rows={2}
+              alwaysShowToolbar
+              submitLabel="Post note"
+            />
           )}
-        </form>
+        </div>
 
         {/* Updates list */}
         {updates.length > 0 ? (

--- a/src/components/SmartCompose.tsx
+++ b/src/components/SmartCompose.tsx
@@ -1,10 +1,28 @@
-// SmartCompose — dark-themed compose surface for TodayPage/UnifiedMyTasks
-// task drawers. Real @-mention via MentionInput, emoji picker, file attach
-// via the R2 upload flow, Cmd+Enter to post.
+// SmartCompose — shared compose surface with @mention (MentionInput),
+// emoji picker, file attach via R2 presigned URL flow, Cmd+Enter to post.
 //
-// Closes Phase 38 eval Issue 8 (compose toolbar @/:/📎 were decorative).
+// Two modes:
+//   1) **Task mode** (default): pass `taskId`. SmartCompose owns its
+//      state and calls `usePostTaskUpdate(taskId)` on Cmd+Enter.
+//      Used by TaskDetailDrawer, MyTasks InlineDetail/TaskDrawer.
+//
+//   2) **Custom mode**: pass `onSubmit` (and optionally `value` + `onChange`
+//      to share state) plus `uploadContext` for R2 keying. SmartCompose
+//      becomes a presentation primitive — caller owns submission.
+//      Used by ProjectDetail compose, ProjectUpdateFeed, ProjectComments,
+//      MeetingDetail (notes + action items), AskTheLab, TodayPage morning
+//      thought, RightNow chat. (D14 — Phase A foundations.)
+//
+// Closes Phase 38 eval Issue 8 (compose toolbar @/:/📎 were decorative)
+// and the audit-2026-04-28 D14 SmartCompose-universal sweep.
+//
+// Two surface variants:
+//   - `theme="dark"` (default): renders inside dark portal chrome
+//     (TodayPage / drawers). Hex-pinned dark colors.
+//   - `theme="light"` (boxed=false default): renders inside the cream/ice
+//     card shells used by ProjectDetail / MeetingDetail / AskTheLab.
 
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { Paperclip, Smile, AtSign, Loader2 } from 'lucide-react'
 import MentionInput from './MentionInput'
 import { usePostTaskUpdate } from '../hooks/useMutations'
@@ -12,31 +30,125 @@ import { useUndoToast } from './UndoToast'
 
 const EMOJI_QUICK = ['👍', '❤️', '🎉', '👀', '🔥', '💡', '✅', '⚠️', '📝', '🤖', '🚀', '🙏']
 
-const INK = '#e2e8f0'
-const INK_DIM = '#7a828c'
+const INK_DARK = '#e2e8f0'
+const INK_DIM_DARK = '#7a828c'
 const ACCENT_GOLD = '#c9a84c'
 const ACCENT_TEAL = '#5cbcb4'
 
-interface SmartComposeProps {
-  taskId: string
+export type SmartComposeUploadContext = {
+  /** Server-side context.type for /api/upload/url. */
+  type: 'task' | 'project' | 'meeting' | 'question' | 'answer' | 'daily_thought' | 'note'
+  /** Server-side context.id (e.g., task slug, project slug, meeting id). */
+  id: string
+  /** Optional: override the entityType used at /api/upload/done.
+   *  Defaults to `type`. Some surfaces (e.g., daily_thought) won't have a
+   *  matching attachments table — caller can pass a fallback like 'task'. */
+  entityType?: string
+}
+
+interface BaseProps {
   placeholder?: string
   /** When true, the compose is wrapped with a labeled "Add note" header
    *  (UnifiedMyTasks drawer style). When false, just the textarea + toolbar
-   *  (TodayPage drawer inline style). */
+   *  (TodayPage drawer inline style). Only applies to dark theme. */
   boxed?: boolean
+  /** 'dark' (default — TodayPage/drawer chrome) or 'light' (project/meeting/asktl). */
+  theme?: 'dark' | 'light'
+  /** Hide the wrapper margin/divider so caller controls spacing. */
+  bare?: boolean
+  /** rows for the textarea; default 2. */
+  rows?: number
+  /** Auto-focus the textarea on mount (e.g. when opening a chat slot). */
+  autoFocus?: boolean
+  /** Force the toolbar visible even when not focused/empty. */
+  alwaysShowToolbar?: boolean
+  /** Submit button label override; default "Post". */
+  submitLabel?: string
+  /** Posting label override; default "Posting…". */
+  submittingLabel?: string
+  /** Hide the ⌘⏎ kbd hint. */
+  hideKbdHint?: boolean
 }
 
-export default function SmartCompose({ taskId, placeholder = 'Add a note, or @hermes for AI…', boxed = false }: SmartComposeProps) {
-  const [val, setVal] = useState('')
+interface TaskModeProps extends BaseProps {
+  taskId: string
+  onSubmit?: never
+  value?: never
+  onChange?: never
+  submitting?: never
+  uploadContext?: SmartComposeUploadContext
+}
+
+interface CustomModeProps extends BaseProps {
+  taskId?: undefined
+  /** Custom submit. Receives raw textarea content (caller trims). */
+  onSubmit: (content: string) => Promise<void> | void
+  /** Optional controlled value. If omitted, SmartCompose owns state. */
+  value?: string
+  onChange?: (next: string) => void
+  /** External pending state (e.g. mutation.isPending). */
+  submitting?: boolean
+  /** R2 upload context. Required to enable file attach in custom mode. */
+  uploadContext?: SmartComposeUploadContext
+}
+
+type SmartComposeProps = TaskModeProps | CustomModeProps
+
+export default function SmartCompose(props: SmartComposeProps) {
+  const {
+    placeholder = 'Add a note, or @hermes for AI…',
+    boxed = false,
+    theme = 'dark',
+    bare = false,
+    rows = 2,
+    autoFocus = false,
+    alwaysShowToolbar = false,
+    submitLabel = 'Post',
+    submittingLabel = 'Posting…',
+    hideKbdHint = false,
+  } = props
+
+  const isCustomMode = 'onSubmit' in props && typeof props.onSubmit === 'function'
+  const taskMutation = usePostTaskUpdate(isCustomMode ? '' : (props as TaskModeProps).taskId)
+
+  // State: caller-controlled in custom mode (if value/onChange provided), else owned here.
+  const [internalVal, setInternalVal] = useState('')
+  const isControlled = isCustomMode && typeof (props as CustomModeProps).value === 'string'
+  const val = isControlled ? ((props as CustomModeProps).value as string) : internalVal
+  const setVal = useCallback((next: string | ((cur: string) => string)) => {
+    if (isControlled) {
+      const onChange = (props as CustomModeProps).onChange
+      if (!onChange) return
+      const resolved = typeof next === 'function' ? (next as (cur: string) => string)(val) : next
+      onChange(resolved)
+    } else {
+      setInternalVal((cur) => (typeof next === 'function' ? (next as (cur: string) => string)(cur) : next))
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isControlled, val])
+
   const [focused, setFocused] = useState(false)
   const [emojiOpen, setEmojiOpen] = useState(false)
   const [uploading, setUploading] = useState(false)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const post = usePostTaskUpdate(taskId)
   const undoToast = useUndoToast()
 
-  const showToolbar = focused || val.length > 0 || emojiOpen
+  useEffect(() => {
+    if (autoFocus && textareaRef.current) textareaRef.current.focus()
+  }, [autoFocus])
+
+  const externalSubmitting = isCustomMode ? !!(props as CustomModeProps).submitting : taskMutation.isPending
+  const submitting = externalSubmitting
+
+  const showToolbar = alwaysShowToolbar || focused || val.length > 0 || emojiOpen
+
+  // R2 upload context — task mode falls back to {type:'task', id: taskId}.
+  const uploadContext: SmartComposeUploadContext | null = (() => {
+    if (isCustomMode) return (props as CustomModeProps).uploadContext ?? null
+    const t = (props as TaskModeProps).taskId
+    return { type: 'task', id: t, entityType: 'task' }
+  })()
 
   const insertAtCursor = useCallback((insertion: string) => {
     setVal((current) => {
@@ -52,18 +164,30 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
       })
       return next
     })
-  }, [])
+  }, [setVal])
 
-  const submit = useCallback(() => {
+  const submit = useCallback(async () => {
     const content = val.trim()
     if (!content) return
-    post.mutate({ content }, {
-      onSuccess: () => {
-        setVal('')
-        undoToast.showSuccess('Note posted')
-      },
-    })
-  }, [val, post, undoToast])
+    if (isCustomMode) {
+      const onSubmit = (props as CustomModeProps).onSubmit
+      try {
+        await onSubmit(content)
+        // Clear when caller didn't control state. If controlled, it's the caller's
+        // job to clear (in case they want to retry on error etc.).
+        if (!isControlled) setVal('')
+      } catch (err) {
+        console.error('SmartCompose submit failed:', err)
+      }
+    } else {
+      taskMutation.mutate({ content }, {
+        onSuccess: () => {
+          setVal('')
+          undoToast.showSuccess('Note posted')
+        },
+      })
+    }
+  }, [val, isCustomMode, props, isControlled, setVal, taskMutation, undoToast])
 
   const onKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
@@ -74,7 +198,7 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
 
   const handleFiles = useCallback(async (files: FileList | null) => {
     const file = files?.[0]
-    if (!file) return
+    if (!file || !uploadContext) return
     setUploading(true)
     try {
       const urlRes = await fetch('/api/upload/url', {
@@ -83,7 +207,7 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
         body: JSON.stringify({
           filename: file.name,
           contentType: file.type || 'application/octet-stream',
-          context: { type: 'task', id: taskId },
+          context: { type: uploadContext.type, id: uploadContext.id },
         }),
       })
       const urlData = await urlRes.json() as { data?: { uploadUrl: string; key: string } }
@@ -101,12 +225,12 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
           filename: file.name,
           contentType: file.type,
           sizeBytes: file.size,
-          entityType: 'task',
-          entityId: taskId,
+          entityType: uploadContext.entityType ?? uploadContext.type,
+          entityId: uploadContext.id,
         }),
       })
-      const doneData = await doneRes.json() as { data?: { downloadUrl?: string } }
-      const url = doneData.data?.downloadUrl ?? `/api/files/${urlData.data.key}`
+      const doneData = await doneRes.json() as { data?: { downloadUrl?: string; url?: string } }
+      const url = doneData.data?.downloadUrl ?? doneData.data?.url ?? `/api/files/${urlData.data.key}`
       insertAtCursor(`[${file.name}](${url}) `)
       undoToast.showSuccess(`Attached ${file.name}`)
     } catch (err) {
@@ -115,7 +239,55 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
     } finally {
       setUploading(false)
     }
-  }, [taskId, insertAtCursor, undoToast])
+  }, [uploadContext, insertAtCursor, undoToast])
+
+  const handlePaste = useCallback((e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!uploadContext) return
+    const items = Array.from(e.clipboardData?.items || [])
+    const fileItem = items.find((it) => it.kind === 'file')
+    if (fileItem) {
+      e.preventDefault()
+      const f = fileItem.getAsFile()
+      if (f) {
+        const dt = new DataTransfer()
+        dt.items.add(f)
+        handleFiles(dt.files)
+      }
+    }
+  }, [uploadContext, handleFiles])
+
+  const isDark = theme === 'dark'
+
+  // Themed styles ------------------------------------------------
+  const textareaStyle: React.CSSProperties = isDark
+    ? {
+        width: '100%',
+        background: 'rgba(255,255,255,0.02)',
+        border: '1px solid rgba(255,255,255,0.06)',
+        borderRadius: 4,
+        padding: '6px 10px',
+        color: INK_DARK,
+        fontSize: 12,
+        fontFamily: 'inherit',
+        outline: 'none',
+        resize: 'vertical',
+      }
+    : {
+        width: '100%',
+        background: 'var(--cream)',
+        border: '1px solid var(--border-subtle)',
+        borderRadius: 'var(--radius-md)',
+        padding: '8px 10px',
+        color: 'var(--ink)',
+        fontSize: 13,
+        fontFamily: 'inherit',
+        outline: 'none',
+        resize: 'vertical',
+        lineHeight: 1.4,
+      }
+
+  const submitBg = isDark ? ACCENT_GOLD : 'var(--teal-solid)'
+  const submitColor = isDark ? '#0b1017' : 'var(--ink-bright, #fff)'
 
   const inner = (
     <>
@@ -126,16 +298,18 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
         onKeyDown={onKeyDown}
         onFocus={() => setFocused(true)}
         onBlur={() => setTimeout(() => setFocused(false), 100) /* let buttons handle clicks first */}
-        rows={2}
-        style={{ width: '100%', background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.06)', borderRadius: 4, padding: '6px 10px', color: INK, fontSize: 12, fontFamily: 'inherit', outline: 'none', resize: 'vertical' }}
+        rows={rows}
+        style={textareaStyle}
       />
       {showToolbar && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, marginTop: 6, position: 'relative' }}>
-          <ToolbarBtn label="Mention someone" onClick={() => insertAtCursor('@')}><AtSign size={11} /></ToolbarBtn>
-          <ToolbarBtn label="Add emoji" onClick={() => setEmojiOpen((o) => !o)} active={emojiOpen}><Smile size={11} /></ToolbarBtn>
-          <ToolbarBtn label="Attach file" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
-            {uploading ? <Loader2 size={11} className="animate-spin" /> : <Paperclip size={11} />}
-          </ToolbarBtn>
+          <ToolbarBtn theme={theme} label="Mention someone" onClick={() => insertAtCursor('@')}><AtSign size={11} /></ToolbarBtn>
+          <ToolbarBtn theme={theme} label="Add emoji" onClick={() => setEmojiOpen((o) => !o)} active={emojiOpen}><Smile size={11} /></ToolbarBtn>
+          {uploadContext && (
+            <ToolbarBtn theme={theme} label="Attach file" onClick={() => fileInputRef.current?.click()} disabled={uploading}>
+              {uploading ? <Loader2 size={11} className="animate-spin" /> : <Paperclip size={11} />}
+            </ToolbarBtn>
+          )}
           <input
             ref={fileInputRef}
             type="file"
@@ -143,7 +317,20 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
             onChange={(e) => { handleFiles(e.target.files); e.target.value = '' }}
           />
           {emojiOpen && (
-            <div style={{ position: 'absolute', bottom: '100%', left: 0, marginBottom: 6, padding: 6, background: '#0f1923', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 6, display: 'flex', gap: 2, zIndex: 20, boxShadow: '0 4px 12px rgba(0,0,0,0.4)' }}>
+            <div style={{
+              position: 'absolute',
+              bottom: '100%',
+              left: 0,
+              marginBottom: 6,
+              padding: 6,
+              background: isDark ? '#0f1923' : 'var(--cream)',
+              border: isDark ? '1px solid rgba(255,255,255,0.12)' : '1px solid var(--border-subtle)',
+              borderRadius: 6,
+              display: 'flex',
+              gap: 2,
+              zIndex: 20,
+              boxShadow: isDark ? '0 4px 12px rgba(0,0,0,0.4)' : 'var(--shadow-menu)',
+            }}>
               {EMOJI_QUICK.map((e) => (
                 <button
                   key={e}
@@ -151,7 +338,7 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
                   onMouseDown={(ev) => ev.preventDefault()}
                   onClick={() => { insertAtCursor(e); setEmojiOpen(false) }}
                   style={{ width: 24, height: 24, fontSize: 15, background: 'transparent', border: 'none', cursor: 'pointer', borderRadius: 3 }}
-                  onMouseEnter={(ev) => { ev.currentTarget.style.background = 'rgba(255,255,255,0.08)' }}
+                  onMouseEnter={(ev) => { ev.currentTarget.style.background = isDark ? 'rgba(255,255,255,0.08)' : 'var(--gold-active)' }}
                   onMouseLeave={(ev) => { ev.currentTarget.style.background = 'transparent' }}
                 >{e}</button>
               ))}
@@ -162,32 +349,73 @@ export default function SmartCompose({ taskId, placeholder = 'Add a note, or @he
             <button
               type="button"
               onClick={submit}
-              disabled={post.isPending}
-              style={{ padding: '3px 10px', fontSize: 11, background: ACCENT_GOLD, color: '#0b1017', border: 'none', borderRadius: 3, cursor: post.isPending ? 'wait' : 'pointer', fontFamily: 'inherit', fontWeight: 600 }}
-            >{post.isPending ? 'Posting…' : 'Post'}</button>
+              disabled={submitting}
+              style={{
+                padding: isDark ? '3px 10px' : '4px 12px',
+                fontSize: 11,
+                background: submitBg,
+                color: submitColor,
+                border: 'none',
+                borderRadius: isDark ? 3 : 'var(--radius-sm)' as any,
+                cursor: submitting ? 'wait' : 'pointer',
+                fontFamily: 'inherit',
+                fontWeight: 600,
+              }}
+            >{submitting ? submittingLabel : submitLabel}</button>
           )}
-          <kbd style={{ fontFamily: 'var(--font-mono), JetBrains Mono, monospace', fontSize: 9, padding: '1px 4px', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 2, color: INK_DIM }}>⌘ ⏎</kbd>
+          {!hideKbdHint && (
+            <kbd style={{
+              fontFamily: 'var(--font-mono), JetBrains Mono, monospace',
+              fontSize: 9,
+              padding: '1px 4px',
+              border: isDark ? '1px solid rgba(255,255,255,0.08)' : '1px solid var(--border-subtle)',
+              borderRadius: 2,
+              color: isDark ? INK_DIM_DARK : 'var(--muted)',
+            }}>⌘ ⏎</kbd>
+          )}
         </div>
       )}
     </>
   )
 
-  if (boxed) {
-    return (
-      <div style={{ marginTop: 18, padding: '10px 12px', background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.05)', borderRadius: 4 }}>
-        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.10em', textTransform: 'uppercase', color: INK_DIM, marginBottom: 6 }}>Add note</div>
-        {inner}
-      </div>
-    )
-  }
-  return (
-    <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px dashed rgba(255,255,255,0.08)' }}>
+  // Hidden paste handler — registers on the textarea via MentionInput
+  // doesn't expose paste; attach via a wrapper so paste-image works.
+  const composeWrapper = (
+    <div onPaste={handlePaste as unknown as React.ClipboardEventHandler<HTMLDivElement>}>
       {inner}
     </div>
   )
+
+  if (bare) return composeWrapper
+
+  if (isDark && boxed) {
+    return (
+      <div style={{ marginTop: 18, padding: '10px 12px', background: 'rgba(255,255,255,0.02)', border: '1px solid rgba(255,255,255,0.05)', borderRadius: 4 }}>
+        <div style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.10em', textTransform: 'uppercase', color: INK_DIM_DARK, marginBottom: 6 }}>Add note</div>
+        {composeWrapper}
+      </div>
+    )
+  }
+
+  if (isDark) {
+    return (
+      <div style={{ marginTop: 14, paddingTop: 12, borderTop: '1px dashed rgba(255,255,255,0.08)' }}>
+        {composeWrapper}
+      </div>
+    )
+  }
+
+  // Light theme — flush wrapper, caller controls spacing via `bare` or wrapping.
+  return composeWrapper
 }
 
-function ToolbarBtn({ children, onClick, label, active, disabled }: { children: React.ReactNode; onClick: () => void; label: string; active?: boolean; disabled?: boolean }) {
+function ToolbarBtn({ children, onClick, label, active, disabled, theme }: { children: React.ReactNode; onClick: () => void; label: string; active?: boolean; disabled?: boolean; theme?: 'dark' | 'light' }) {
+  const isDark = theme !== 'light'
+  const baseColor = isDark ? INK_DIM_DARK : 'var(--slate)' as any
+  const activeColor = isDark ? ACCENT_TEAL : 'var(--teal)'
+  const baseBorder = isDark ? '1px solid rgba(255,255,255,0.06)' : '1px solid var(--border-subtle)'
+  const activeBorder = isDark ? '1px solid rgba(92,188,180,0.30)' : '1px solid var(--teal)'
+  const activeBg = isDark ? 'rgba(92,188,180,0.15)' : 'var(--teal-active)'
   return (
     <button
       type="button"
@@ -199,16 +427,16 @@ function ToolbarBtn({ children, onClick, label, active, disabled }: { children: 
       style={{
         display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
         width: 22, height: 22, borderRadius: 4,
-        background: active ? 'rgba(92,188,180,0.15)' : 'transparent',
-        border: `1px solid ${active ? 'rgba(92,188,180,0.30)' : 'rgba(255,255,255,0.06)'}`,
-        color: active ? ACCENT_TEAL : INK_DIM,
+        background: active ? activeBg : 'transparent',
+        border: active ? activeBorder : baseBorder,
+        color: active ? activeColor : baseColor,
         fontSize: 11,
         cursor: disabled ? 'not-allowed' : 'pointer',
         opacity: disabled ? 0.5 : 1,
         fontFamily: 'inherit',
       }}
-      onMouseEnter={(e) => { if (!disabled && !active) { e.currentTarget.style.color = ACCENT_TEAL; e.currentTarget.style.borderColor = 'rgba(92,188,180,0.30)' } }}
-      onMouseLeave={(e) => { if (!disabled && !active) { e.currentTarget.style.color = INK_DIM; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.06)' } }}
+      onMouseEnter={(e) => { if (!disabled && !active) { e.currentTarget.style.color = activeColor as string; e.currentTarget.style.borderColor = isDark ? 'rgba(92,188,180,0.30)' : 'var(--teal)' } }}
+      onMouseLeave={(e) => { if (!disabled && !active) { e.currentTarget.style.color = baseColor as string; e.currentTarget.style.borderColor = isDark ? 'rgba(255,255,255,0.06)' : 'var(--border-subtle)' } }}
     >{children}</button>
   )
 }

--- a/src/components/SmartCompose.tsx
+++ b/src/components/SmartCompose.tsx
@@ -68,6 +68,8 @@ interface BaseProps {
   submittingLabel?: string
   /** Hide the ⌘⏎ kbd hint. */
   hideKbdHint?: boolean
+  /** Hide the inline Post button (e.g., when the surrounding form supplies its own submit). */
+  hideSubmitButton?: boolean
 }
 
 interface TaskModeProps extends BaseProps {
@@ -106,6 +108,7 @@ export default function SmartCompose(props: SmartComposeProps) {
     submitLabel = 'Post',
     submittingLabel = 'Posting…',
     hideKbdHint = false,
+    hideSubmitButton = false,
   } = props
 
   const isCustomMode = 'onSubmit' in props && typeof props.onSubmit === 'function'
@@ -345,7 +348,7 @@ export default function SmartCompose(props: SmartComposeProps) {
             </div>
           )}
           <span style={{ flex: 1 }} />
-          {val.trim().length > 0 && (
+          {!hideSubmitButton && val.trim().length > 0 && (
             <button
               type="button"
               onClick={submit}

--- a/src/components/today/MorningThoughtCompose.tsx
+++ b/src/components/today/MorningThoughtCompose.tsx
@@ -1,0 +1,142 @@
+// MorningThoughtCompose — TP-01 (D11 prefix-routed + time-aware morning input).
+//
+// Replaces the bare decorative <input> at TodayPage.tsx with a real submit
+// handler. Routing rules per audit decision D11:
+//
+//   `@hermes <text>` → POST /api/ai-requests with source_type='daily_thought'
+//   `note: <text>`   → append to today_state_${YYYY-MM-DD}.thoughts (LS array)
+//   default          → useCreateTask({assignee, group_override}) — creates
+//                      a task in the user's default bucket (priorities)
+//
+// Time-aware (after 5pm CT — local hour >= 17):
+//   - placeholder swaps to "Plan tomorrow's first move…"
+//   - default tasks get due_date = tomorrow
+//
+// The brief says to use SmartCompose; we do — `theme="dark"` + `bare` so the
+// existing PANEL_BG container styling on TodayPage stays intact.
+
+import { useCallback, useMemo } from 'react'
+import SmartCompose from '../SmartCompose'
+import { useAuth } from '../../hooks/useAuth'
+import { emailToSlug } from '../../lib/emailSlug'
+import { useCreateTask } from '../../hooks/useMutations'
+import { useUndoToast } from '../UndoToast'
+import { todayKey } from './constants'
+
+const DEFAULT_GROUP_OVERRIDE = 'priorities'
+
+function tomorrowISO(): string {
+  const d = new Date()
+  d.setDate(d.getDate() + 1)
+  return d.toISOString().slice(0, 10)
+}
+
+function appendDailyThought(content: string, kind: 'note' | 'hermes' | 'task') {
+  if (typeof window === 'undefined') return
+  const key = `today_state_${todayKey()}`
+  try {
+    const raw = window.localStorage.getItem(key)
+    const state = raw ? JSON.parse(raw) : {}
+    const thoughts = Array.isArray(state.thoughts) ? state.thoughts : []
+    thoughts.push({ at: new Date().toISOString(), kind, content })
+    state.thoughts = thoughts
+    window.localStorage.setItem(key, JSON.stringify(state))
+  } catch { /* ignore */ }
+}
+
+export function MorningThoughtCompose() {
+  const { user } = useAuth()
+  const userSlug = emailToSlug(user?.email)
+  const createTask = useCreateTask()
+  const undoToast = useUndoToast()
+
+  // Compute "after 5pm" once per render — reasonable for the mount lifetime
+  // of this surface. Page is a daily landing; user reloads if they cross 5pm.
+  const isEvening = useMemo(() => new Date().getHours() >= 17, [])
+  const placeholder = isEvening
+    ? "Plan tomorrow's first move, or @hermes to delegate…"
+    : 'Morning thought, quick capture, or @hermes to delegate…'
+
+  const handleSubmit = useCallback(async (raw: string) => {
+    const content = raw.trim()
+    if (!content) return
+
+    // Route 1 — @hermes prefix
+    if (/^@hermes\b/i.test(content)) {
+      const prompt = content.replace(/^@hermes\s*/i, '').trim() || content
+      try {
+        const res = await fetch('/api/ai-requests', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            source_type: 'daily_thought',
+            source_id: todayKey(),
+            prompt,
+          }),
+        })
+        if (!res.ok) throw new Error(`/api/ai-requests ${res.status}`)
+        appendDailyThought(content, 'hermes')
+        undoToast.showSuccess('Sent to Hermes')
+      } catch (err) {
+        console.error('Morning thought → Hermes failed:', err)
+        alert(`Sending to Hermes failed: ${err instanceof Error ? err.message : 'unknown'}`)
+      }
+      return
+    }
+
+    // Route 2 — note: prefix
+    if (/^note:\s*/i.test(content)) {
+      const text = content.replace(/^note:\s*/i, '').trim()
+      if (!text) return
+      appendDailyThought(text, 'note')
+      undoToast.showSuccess('Saved to today\'s thoughts')
+      return
+    }
+
+    // Route 3 — default: create a task in the user's default group.
+    if (!userSlug) {
+      alert('Sign in to capture tasks.')
+      return
+    }
+    const due_date = isEvening ? tomorrowISO() : undefined
+    return new Promise<void>((resolve) => {
+      createTask.mutate({
+        title: content,
+        description: content,
+        assignee: userSlug,
+        ...(due_date ? { due_date } : {}),
+        // useCreateTask's input type doesn't yet enumerate group_override —
+        // pass it via spread so the backend (which accepts it via VALID_GROUP_OVERRIDES)
+        // captures it. If the type guard rejects, falls through harmless.
+        // (Hub-side createTask wraps fetchApi; group_override is a top-level
+        // body field on POST /api/tasks per CLAUDE.md Rule 63.)
+        // @ts-expect-error — group_override not in TS input but accepted by API
+        group_override: DEFAULT_GROUP_OVERRIDE,
+      }, {
+        onSuccess: () => {
+          appendDailyThought(content, 'task')
+          undoToast.showSuccess(isEvening ? 'Tomorrow task captured' : 'Task captured')
+          resolve()
+        },
+        onError: (err: unknown) => {
+          console.error('Morning thought → task failed:', err)
+          resolve() // resolve anyway so SmartCompose clears its UI lock
+        },
+      })
+    })
+  }, [userSlug, isEvening, createTask, undoToast])
+
+  return (
+    <SmartCompose
+      placeholder={placeholder}
+      theme="dark"
+      bare
+      rows={1}
+      submitLabel="Capture"
+      submittingLabel="Capturing…"
+      onSubmit={handleSubmit}
+      submitting={createTask.isPending}
+      uploadContext={{ type: 'daily_thought', id: todayKey(), entityType: 'task' }}
+    />
+  )
+}

--- a/src/components/today/RightNowCard.tsx
+++ b/src/components/today/RightNowCard.tsx
@@ -13,6 +13,7 @@ import { LinkRow } from './primitives'
 import { ACCENT_GOLD, INK, INK_MUTED, INK_DIM, PAGE_BG, type LinkKind } from './constants'
 import type { TodayStateApi } from '../../hooks/useTodayState'
 import type { TaskRow } from '../../lib/api'
+import SmartCompose from '../SmartCompose'
 
 export function RightNow({ task, project, queueTasks, state }: { task: TaskRow | null; project: { name: string; slug: string } | null; queueTasks: Array<{ id: string; title: string }>; state: TodayStateApi }) {
   const [expanded, setExpanded] = useState(false)
@@ -63,12 +64,18 @@ export function RightNow({ task, project, queueTasks, state }: { task: TaskRow |
           {task.description && (
             <div style={{ fontSize: 12, color: INK_MUTED, marginBottom: 8, fontStyle: 'italic' }}>{task.description.split('\n')[0].slice(0, 280)}</div>
           )}
-          <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-            <span style={{ fontSize: 12, color: ACCENT_GOLD }}>💬</span>
-            <input
-              placeholder="Chat with Claude about this task…"
-              style={{ flex: 1, background: 'rgba(0,0,0,0.20)', border: '1px solid rgba(255,255,255,0.06)', borderRadius: 4, padding: '5px 10px', fontSize: 12, color: INK, outline: 'none', fontFamily: 'inherit' }}
-            />
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+            <span style={{ fontSize: 12, color: ACCENT_GOLD, marginTop: 4 }}>💬</span>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <SmartCompose
+                taskId={task.id}
+                placeholder="Chat with Claude about this task… (@hermes for AI)"
+                theme="dark"
+                bare
+                rows={1}
+                autoFocus
+              />
+            </div>
           </div>
         </div>
       )}

--- a/src/pages/MeetingDetail.tsx
+++ b/src/pages/MeetingDetail.tsx
@@ -22,9 +22,6 @@ import {
   Check,
   X,
   Sparkles,
-  Paperclip,
-  AtSign,
-  Smile,
   Upload as UploadIcon,
 } from 'lucide-react'
 import { DndContext, closestCenter, PointerSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core'
@@ -38,7 +35,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useToggleActionItem, useAddAgendaItem, useUpdateMeetingNotes, useCreateDecision, useCreateTask } from '../hooks/useMutations'
 import FileUpload from '../components/FileUpload'
 import TypingIndicator from '../components/TypingIndicator'
-import { appendCharToInput, parseCarriedForward } from '../lib/textUtils'
+import { parseCarriedForward } from '../lib/textUtils'
 import { parseQuickAddInput } from '../lib/parseQuickAdd'
 import { emailToSlug } from '../lib/emailSlug'
 import { useAuth } from '../hooks/useAuth'
@@ -55,6 +52,7 @@ import { getPersonInfo, getMemberBySlug, directors, getAllMembers } from '../dat
 import { formatLongDate, formatShortDate } from '../lib/dateUtils'
 import { getMeetingFacilitator } from '../lib/facilitator'
 import { PATHS } from '../constants/paths'
+import SmartCompose from '../components/SmartCompose'
 
 function buildMemberHoverData(slug: string): HoverCardData {
   const p = getPersonInfo(slug)
@@ -1029,12 +1027,7 @@ const PRIORITY_COLORS: Record<number, string> = { 1: 'var(--maroon)', 2: 'var(--
 
 function AddActionItemForm({ meetingId, isAuthenticated, onSuccess, onContentChange }: { meetingId: string; isAuthenticated: boolean; onSuccess: () => void; onContentChange?: (hasContent: boolean) => void }) {
   const [text, setText] = useState('')
-  const [dragOver, setDragOver] = useState(false)
-  const [uploading, setUploading] = useState(false)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const fileInputRef = useRef<HTMLInputElement>(null)
   const { typingPeers: meetingTypingPeers, broadcastTyping: broadcastMeetingTyping } = useTyping('meeting', meetingId)
-  const appendCh = (ch: string) => appendCharToInput(inputRef, ch, setText)
   const createTask = useCreateTask()
   const queryClient = useQueryClient()
   const { user } = useAuth()
@@ -1043,146 +1036,69 @@ function AddActionItemForm({ meetingId, isAuthenticated, onSuccess, onContentCha
   const parsed = text.trim() ? parseQuickAddInput(text) : null
   const hasContent = parsed && parsed.title.trim().length > 0
 
-  // T-04 inline file drop on meeting action-item compose. Files attach to
-  // the meeting (not the forthcoming task) — R2 flow mirrors FileUpload.
-  const uploadToCompose = async (file: File) => {
-    setUploading(true)
-    try {
-      const urlRes = await fetch('/api/upload/url', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ filename: file.name, contentType: file.type || 'application/octet-stream', context: { type: 'meeting', id: meetingId } }),
-      })
-      const urlData = await urlRes.json() as { data?: { uploadUrl?: string; key?: string } }
-      if (!urlData.data?.uploadUrl || !urlData.data?.key) throw new Error('presign failed')
-      await fetch(urlData.data.uploadUrl, { method: 'PUT', body: file, headers: { 'Content-Type': file.type || 'application/octet-stream' } })
-      const doneRes = await fetch('/api/upload/done', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ key: urlData.data.key, filename: file.name, contentType: file.type, sizeBytes: file.size, entityType: 'meeting', entityId: meetingId }),
-      })
-      const doneData = await doneRes.json() as { data?: { url?: string } }
-      queryClient.invalidateQueries({ queryKey: ['attachments', 'meeting', meetingId] })
-      const link = doneData.data?.url ?? `/api/files/${urlData.data.key}`
-      setText((prev) => (prev ? `${prev} [${file.name}](${link})` : `[${file.name}](${link})`))
-    } catch (err) {
-      console.error('meeting compose upload failed', err)
-    } finally {
-      setUploading(false)
-    }
-  }
+  // SmartCompose now owns the textarea, paperclip (R2 → meeting context),
+  // @-mention dropdown, emoji palette, paste-image, Cmd+Enter.
+  // We retain `text` state at this level so:
+  //   1) parseQuickAddInput runs on every keystroke for live token preview
+  //   2) presence broadcast fires from onChange
+  //   3) submission still goes through createTask + onSuccess
 
-  function handleSubmit(e: React.FormEvent) {
-    e.preventDefault()
-    if (!parsed || !hasContent) return
-
-    createTask.mutate({
-      title: parsed.title,
-      description: parsed.title,
-      assignee: parsed.assigneeSlug ?? fallbackAssignee,
-      meeting_id: meetingId,
-      due_date: parsed.dueDate ?? undefined,
-      priority: parsed.priority === 1 ? 'urgent' : parsed.priority === 2 ? 'high' : parsed.priority === 3 ? 'medium' : 'medium',
-    }, {
-      onSuccess: () => {
-        setText('')
-        queryClient.invalidateQueries({ queryKey: ['meeting', meetingId] })
-        onSuccess()
-        inputRef.current?.focus()
-      },
+  const handleSubmit = async (raw: string) => {
+    const p = parseQuickAddInput(raw)
+    if (!p?.title.trim()) return
+    return new Promise<void>((resolve) => {
+      createTask.mutate({
+        title: p.title,
+        description: p.title,
+        assignee: p.assigneeSlug ?? fallbackAssignee,
+        meeting_id: meetingId,
+        due_date: p.dueDate ?? undefined,
+        priority: p.priority === 1 ? 'urgent' : p.priority === 2 ? 'high' : p.priority === 3 ? 'medium' : 'medium',
+      }, {
+        onSuccess: () => {
+          setText('')
+          broadcastMeetingTyping(false)
+          onContentChange?.(false)
+          queryClient.invalidateQueries({ queryKey: ['meeting', meetingId] })
+          onSuccess()
+          resolve()
+        },
+        onError: () => resolve(),
+      })
     })
   }
 
   return (
-    <form onSubmit={handleSubmit} style={{ marginBottom: '12px', paddingBottom: '12px', borderBottom: '1px solid rgba(45,138,138,0.08)' }}>
-      <div
-        className="flex items-center gap-2"
-        onDragOver={(e) => { e.preventDefault(); setDragOver(true) }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => { e.preventDefault(); setDragOver(false); Array.from(e.dataTransfer.files || []).forEach(uploadToCompose) }}
-        style={{ outline: dragOver ? '2px dashed var(--teal)' : 'none', outlineOffset: '2px', borderRadius: 'var(--radius-lg)' }}
-      >
-        <Plus size={14} style={{ color: 'var(--teal)', opacity: 0.85, flexShrink: 0 }} />
-        <input
-          ref={inputRef}
-          type="text"
-          data-testid="meeting-action-add"
-          value={text}
-          onChange={(e) => {
-            const v = e.target.value
-            setText(v)
-            const hasContent = v.trim().length > 0
-            broadcastMeetingTyping(hasContent)
-            onContentChange?.(hasContent)
-          }}
-          onPaste={(e) => {
-            const fi = Array.from(e.clipboardData?.items || []).find((it) => it.kind === 'file')
-            if (fi) { e.preventDefault(); const f = fi.getAsFile(); if (f) uploadToCompose(f) }
-          }}
-          placeholder={isAuthenticated || !import.meta.env.PROD ? '@nick Review draft p2 Friday (drop/paste files to attach)' : 'Sign in to add items'}
-          disabled={!isAuthenticated && import.meta.env.PROD}
-          style={{
-            flex: 1, fontSize: 'var(--value-size)', color: 'var(--ink)',
-            background: 'var(--cream)', border: '1px solid color-mix(in srgb, var(--teal) 12%, transparent)', borderRadius: 'var(--radius-lg)',
-            padding: 'var(--sp-sm) var(--sp-md)', outline: 'none', transition: 'border-color 0.15s',
-          }}
-          onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--teal)')}
-          onBlur={(e) => { e.currentTarget.style.borderColor = 'color-mix(in srgb, var(--teal) 12%, transparent)'; broadcastMeetingTyping(false); onContentChange?.(false) }}
-          onKeyDown={(e) => { if (e.key === 'Escape') { setText(''); e.currentTarget.blur() } }}
-        />
-        <button
-          type="button"
-          onClick={() => fileInputRef.current?.click()}
-          disabled={uploading}
-          title="Attach file"
-          className="flex-shrink-0 p-2 rounded-lg"
-          style={{ border: '1px solid var(--border-subtle)', background: 'transparent', color: 'var(--slate)', cursor: uploading ? 'wait' : 'pointer', opacity: uploading ? 0.55 : 0.85 }}
-        >
-          <Paperclip size={12} />
-        </button>
-        <button
-          type="button"
-          onClick={() => appendCh('@')}
-          title="Mention teammate (@name)"
-          className="flex-shrink-0 p-2 rounded-lg"
-          style={{ border: '1px solid var(--border-subtle)', background: 'transparent', color: 'var(--gold)', cursor: 'pointer', opacity: 0.85 }}
-        >
-          <AtSign size={12} />
-        </button>
-        <button
-          type="button"
-          onClick={() => appendCh(':')}
-          title="Add emoji reaction (:emoji:)"
-          className="flex-shrink-0 p-2 rounded-lg"
-          style={{ border: '1px solid var(--border-subtle)', background: 'transparent', color: 'var(--slate)', cursor: 'pointer', opacity: 0.85 }}
-        >
-          <Smile size={12} />
-        </button>
-        <input
-          ref={fileInputRef}
-          type="file"
-          multiple
-          onChange={(e) => { Array.from(e.target.files || []).forEach(uploadToCompose); e.target.value = '' }}
-          style={{ display: 'none' }}
-        />
-        {hasContent && (
-          <motion.button
-            type="submit"
-            initial={{ opacity: 0, scale: 0.8 }}
-            animate={{ opacity: 1, scale: 1 }}
-            className="flex-shrink-0 p-2 rounded-lg cursor-pointer"
-            style={{ background: 'var(--teal-solid)', color: 'white', border: 'none' }}
-          >
-            <Plus size={14} />
-          </motion.button>
-        )}
+    <div style={{ marginBottom: '12px', paddingBottom: '12px', borderBottom: '1px solid rgba(45,138,138,0.08)' }}>
+      <div className="flex items-start gap-2">
+        <Plus size={14} style={{ color: 'var(--teal)', opacity: 0.85, flexShrink: 0, marginTop: 10 }} />
+        <div style={{ flex: 1, minWidth: 0 }}>
+          {!isAuthenticated && import.meta.env.PROD ? (
+            <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75, display: 'inline-block', padding: '8px 0' }}>
+              <a href="/api/auth/login" style={{ color: 'var(--teal)', fontWeight: 'var(--weight-ui)' as any, textDecoration: 'underline' }}>Sign in</a> to add action items
+            </span>
+          ) : (
+            <SmartCompose
+              theme="light"
+              bare
+              value={text}
+              onChange={(next) => {
+                setText(next)
+                const has = next.trim().length > 0
+                broadcastMeetingTyping(has)
+                onContentChange?.(has)
+              }}
+              onSubmit={handleSubmit}
+              submitting={createTask.isPending}
+              uploadContext={{ type: 'meeting', id: meetingId }}
+              placeholder="@nick Review draft p2 Friday (drop/paste files to attach)"
+              rows={1}
+              alwaysShowToolbar={hasContent ?? false}
+              submitLabel="Add"
+            />
+          )}
+        </div>
       </div>
-
-      {!isAuthenticated && import.meta.env.PROD && (
-        <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75, marginLeft: '22px', marginTop: '4px', display: 'inline-block' }}>
-          <a href="/api/auth/login" style={{ color: 'var(--teal)', fontWeight: 'var(--weight-ui)' as any, textDecoration: 'underline' }}>Sign in</a> to add action items
-        </span>
-      )}
 
       <TypingIndicator slugs={meetingTypingPeers} style={{ margin: '4px 0 0 22px' }} />
 
@@ -1225,7 +1141,7 @@ function AddActionItemForm({ meetingId, isAuthenticated, onSuccess, onContentCha
           <span>Apr 15</span>
         </div>
       )}
-    </form>
+    </div>
   )
 }
 

--- a/src/pages/MeetingDetail.tsx
+++ b/src/pages/MeetingDetail.tsx
@@ -746,42 +746,37 @@ export default function MeetingDetail() {
           </div>
           <div style={{ background: 'var(--ice)', borderRadius: 'var(--radius-xl)', padding: '20px' }} className="detail-card">
             {editingNotes ? (
-              <div>
-                <textarea
+              <div onKeyDown={(e) => {
+                if (e.key === 'Escape') {
+                  e.preventDefault()
+                  setNotesDraft(meeting?.notes || '')
+                  setEditingNotes(false)
+                }
+              }}>
+                {/* SmartCompose (D14) — replaces bare textarea. @-mention,
+                    emoji, R2 paperclip via uploadContext={type:'meeting'},
+                    Cmd+Enter triggers Save Notes via onSubmit. */}
+                <SmartCompose
+                  theme="light"
+                  bare
                   value={notesDraft}
-                  onChange={(e) => setNotesDraft(e.target.value)}
+                  onChange={setNotesDraft}
+                  onSubmit={async (content) => {
+                    await new Promise<void>((resolve) => {
+                      updateNotes.mutate(content, { onSuccess: () => resolve(), onError: () => resolve() })
+                    })
+                    setEditingNotes(false)
+                  }}
+                  submitting={updateNotes.isPending}
+                  uploadContext={meeting ? { type: 'meeting', id: meeting.id } : undefined}
+                  placeholder="Meeting notes…"
                   rows={12}
-                  style={{
-                    width: '100%',
-                    fontSize: '14px',
-                    lineHeight: 1.7,
-                    color: 'var(--ink)',
-                    background: 'var(--cream)',
-                    border: '1px solid rgba(201,168,76,0.2)',
-                    borderRadius: 'var(--radius-lg)',
-                    padding: 'var(--sp-md) var(--sp-lg)',
-                    resize: 'vertical',
-                    boxSizing: 'border-box',
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && (e.ctrlKey || e.metaKey)) {
-                      updateNotes.mutate(notesDraft)
-                      setEditingNotes(false)
-                    }
-                    if (e.key === 'Escape') {
-                      setNotesDraft(meeting?.notes || '')
-                      setEditingNotes(false)
-                    }
-                  }}
+                  alwaysShowToolbar
                   autoFocus
+                  submitLabel="Save Notes"
+                  submittingLabel="Saving…"
                 />
                 <div className="flex items-center gap-2 mt-2">
-                  <button
-                    onClick={() => { updateNotes.mutate(notesDraft); setEditingNotes(false) }}
-                    style={{ background: '#dcb355', color: '#1a1a1a', border: 'none', borderRadius: 'var(--radius-md)', padding: '6px 16px', fontSize: 'var(--value-size)', fontWeight: 600, cursor: 'pointer' }}
-                  >
-                    Save Notes
-                  </button>
                   <button
                     onClick={() => { setNotesDraft(meeting?.notes || ''); setEditingNotes(false) }}
                     style={{ background: 'none', border: '1px solid var(--border-subtle)', borderRadius: 'var(--radius-md)', padding: '6px 16px', fontSize: 'var(--value-size)', cursor: 'pointer', color: 'var(--slate)' }}

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -18,9 +18,6 @@ import {
   X,
   Check,
   Link2,
-  Paperclip,
-  AtSign,
-  Smile,
   MoreVertical,
   Archive,
   Trash2,
@@ -33,7 +30,6 @@ import { useUndoToast } from '../components/UndoToast'
 import BulkActionToolbar from '../components/tasks/BulkActionToolbar'
 import { useAuth } from '../hooks/useAuth'
 import { getPersonInfo } from '../data/team'
-import { appendCharToInput } from '../lib/textUtils'
 import TypingIndicator from '../components/TypingIndicator'
 import { formatShortDate, formatMediumDate } from '../lib/dateUtils'
 import Avatar from '../components/Avatar'
@@ -62,6 +58,7 @@ import ProjectLiterature from './project/ProjectLiterature'
 import ProjectActivity from './project/ProjectActivity'
 import ProjectUpdateFeed from '../components/ProjectUpdateFeed'
 import ProjectComments from '../components/ProjectComments'
+import SmartCompose from '../components/SmartCompose'
 import ProjectDocuments from './project/ProjectDocuments'
 import { PATHS } from '../constants/paths'
 
@@ -354,13 +351,9 @@ function ProjectDetailInner({ project }: InnerProps) {
   const isMobile = useIsMobile()
   const [composeSheetOpen, setComposeSheetOpen] = useState(false)
   useComposeSheet(isMobile && composeSheetOpen, () => setComposeSheetOpen(false))
-  const quickComposeFileInputRef = useRef<HTMLInputElement>(null)
-  const quickComposeTextRef = useRef<HTMLTextAreaElement>(null)
-  const appendToCompose = useCallback(
-    (ch: string) => appendCharToInput(quickComposeTextRef, ch, setQuickComposeText),
-    [],
-  )
   // T-04 inline file drop — Slack parity. Upload → append link to compose.
+  // The drag-drop wrapper still calls uploadToCompose; SmartCompose's own
+  // paperclip + paste path uses uploadContext directly.
   const uploadToCompose = useCallback(async (file: File) => {
     if (!project) return
     setQuickComposeUploading(true)
@@ -1221,7 +1214,6 @@ function ProjectDetailInner({ project }: InnerProps) {
             </div>
           </div>
           <div
-            className="flex items-start gap-2"
             onDragOver={(e) => { e.preventDefault(); setQuickComposeDragOver(true) }}
             onDragLeave={() => setQuickComposeDragOver(false)}
             onDrop={(e) => {
@@ -1236,101 +1228,24 @@ function ProjectDetailInner({ project }: InnerProps) {
               outlineOffset: '2px',
             }}
           >
-            <button
-              type="button"
-              onClick={() => quickComposeFileInputRef.current?.click()}
-              disabled={quickComposeUploading}
-              title="Attach file (or drag + drop, or paste an image)"
-              style={{
-                flexShrink: 0, padding: '8px', borderRadius: 'var(--radius-md)',
-                background: 'transparent', color: 'var(--slate)', border: '1px solid var(--border-subtle)',
-                cursor: quickComposeUploading ? 'wait' : 'pointer',
-                opacity: quickComposeUploading ? 0.55 : 0.85,
-              }}
-            >
-              <Paperclip size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={() => appendToCompose('@')}
-              title="Mention teammate (@name)"
-              style={{
-                flexShrink: 0, padding: '8px', borderRadius: 'var(--radius-md)',
-                background: 'transparent', color: 'var(--gold)', border: '1px solid var(--border-subtle)',
-                cursor: 'pointer', opacity: 0.85,
-              }}
-            >
-              <AtSign size={14} />
-            </button>
-            <button
-              type="button"
-              onClick={() => appendToCompose(':')}
-              title="Add emoji reaction (:emoji:)"
-              style={{
-                flexShrink: 0, padding: '8px', borderRadius: 'var(--radius-md)',
-                background: 'transparent', color: 'var(--slate)', border: '1px solid var(--border-subtle)',
-                cursor: 'pointer', opacity: 0.85,
-              }}
-            >
-              <Smile size={14} />
-            </button>
-            <input
-              ref={quickComposeFileInputRef}
-              type="file"
-              multiple
-              onChange={(e) => {
-                const files = Array.from(e.target.files || [])
-                files.forEach(uploadToCompose)
-                e.target.value = ''
-              }}
-              style={{ display: 'none' }}
-            />
-            <textarea
-              ref={quickComposeTextRef}
+            {/* SmartCompose (D14) — replaces the prior decorative @/:/📎
+                button row. @ → MentionInput dropdown, : → emoji palette,
+                paperclip → real R2 upload via uploadContext. State is
+                shared via value/onChange so the BottomSheet trigger label
+                ("Draft: …") still updates and broadcastProjectTyping fires. */}
+            <SmartCompose
+              theme="light"
+              bare
               value={quickComposeText}
-              onChange={(e) => { setQuickComposeText(e.target.value); broadcastProjectTyping(e.target.value.trim().length > 0) }}
-              onPaste={(e) => {
-                const items = Array.from(e.clipboardData?.items || [])
-                const fileItem = items.find((it) => it.kind === 'file')
-                if (fileItem) {
-                  e.preventDefault()
-                  const f = fileItem.getAsFile()
-                  if (f) uploadToCompose(f)
-                }
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-                  e.preventDefault()
-                  handleQuickCompose()
-                }
-              }}
+              onChange={(next) => { setQuickComposeText(next); broadcastProjectTyping(next.trim().length > 0) }}
+              onSubmit={async () => { await handleQuickCompose() }}
+              submitting={quickComposeSubmitting}
+              uploadContext={{ type: 'project', id: project.slug }}
               placeholder={quickComposeKind === 'note' ? 'Post a note... (Cmd+Enter to send, paste or drop to attach)' : 'Comment to team... (Cmd+Enter to send)'}
               rows={2}
-              style={{
-                flex: 1, minWidth: 0, fontSize: '13px', color: 'var(--ink)',
-                background: 'var(--cream)',
-                border: '1px solid var(--border-subtle)',
-                borderRadius: 'var(--radius-md)', padding: '8px 10px',
-                resize: 'none', outline: 'none', lineHeight: 1.4,
-                transition: 'border-color 0.2s',
-              }}
-              onFocus={(e) => (e.currentTarget.style.borderColor = 'var(--teal)')}
-              onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--border-subtle)'; broadcastProjectTyping(false) }}
+              alwaysShowToolbar
+              submitLabel={quickComposeKind === 'note' ? 'Post note' : 'Comment'}
             />
-            {quickComposeText.trim() && (
-              <button
-                type="button"
-                onClick={handleQuickCompose}
-                disabled={quickComposeSubmitting}
-                style={{
-                  flexShrink: 0, padding: '8px 10px', borderRadius: 'var(--radius-md)',
-                  background: 'var(--teal-solid)', color: 'var(--ink-bright, #fff)',
-                  border: 'none', cursor: 'pointer', opacity: quickComposeSubmitting ? 0.6 : 1,
-                }}
-              >
-                <Send size={14} />
-              </button>
-            )}
           </div>
           {quickComposeUploading && (
             <p className="mt-1 text-[10px]" style={{ color: 'var(--teal)', opacity: 0.85 }}>Uploading…</p>

--- a/src/pages/portal/AskTheLab.tsx
+++ b/src/pages/portal/AskTheLab.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useMemo, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { HelpCircle, Plus, X, MessageSquare, Check, ChevronDown, ChevronUp, Send, Search } from 'lucide-react'
+import { HelpCircle, Plus, X, MessageSquare, Check, ChevronDown, ChevronUp, Search } from 'lucide-react'
 import HermesMark from '../../components/HermesMark'
 import HermesResponse from '../../components/HermesResponse'
+import SmartCompose from '../../components/SmartCompose'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CardSkeleton } from '../../components/LoadingSkeleton'
 import PageHeader from '../../components/PageHeader'
@@ -263,14 +264,14 @@ function QuestionExpanded({ questionId }: { questionId: string }) {
   const createAnswerMut = useCreateAnswer(questionId)
   const acceptAnswerMut = useAcceptAnswer(questionId)
 
-  const handleSubmitAnswer = (e: React.FormEvent) => {
-    e.preventDefault()
-    if (!answerText.trim()) return
-    createAnswerMut.mutate(answerText.trim(), {
-      onSuccess: () => showSuccess('Answer posted'),
+  const handleSubmitAnswer = (content: string) =>
+    new Promise<void>((resolve) => {
+      createAnswerMut.mutate(content, {
+        onSuccess: () => { showSuccess('Answer posted'); resolve() },
+        onError: () => resolve(),
+      })
+      setAnswerText('')
     })
-    setAnswerText('')
-  }
 
   if (isLoading || !detail) {
     return (
@@ -386,32 +387,23 @@ function QuestionExpanded({ questionId }: { questionId: string }) {
         </p>
       )}
 
-      {/* Answer form */}
+      {/* Answer form — SmartCompose (D14). */}
       {detail.status === 'open' && (
-        <form onSubmit={handleSubmitAnswer} className="mt-4 flex gap-2">
-          <textarea
+        <div className="mt-4">
+          <SmartCompose
+            theme="light"
+            bare
             value={answerText}
-            onChange={(e) => setAnswerText(e.target.value)}
-            placeholder="Write your answer..."
+            onChange={setAnswerText}
+            onSubmit={handleSubmitAnswer}
+            submitting={createAnswerMut.isPending}
+            uploadContext={{ type: 'answer', id: questionId, entityType: 'question' }}
+            placeholder="Write your answer… (use @hermes for AI)"
             rows={2}
-            className="flex-1 rounded-lg border px-3 py-2 text-sm outline-none resize-none"
-            style={{ borderColor: 'var(--border-subtle)', backgroundColor: 'var(--cream)' }}
+            alwaysShowToolbar
+            submitLabel="Reply"
           />
-          <button
-            type="submit"
-            disabled={!answerText.trim() || createAnswerMut.isPending}
-            className="self-end flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors"
-            style={{
-              backgroundColor: !answerText.trim() ? 'var(--border-subtle)' : 'var(--teal)',
-              color: !answerText.trim() ? 'var(--slate)' : 'var(--ink-bright, #fff)',
-              cursor: !answerText.trim() ? 'not-allowed' : 'pointer',
-              border: 'none',
-            }}
-          >
-            <Send size={14} />
-            Reply
-          </button>
-        </form>
+        </div>
       )}
     </div>
   )
@@ -451,8 +443,7 @@ function CreateQuestionModal({ open, onClose }: { open: boolean; onClose: () => 
     return () => document.removeEventListener('keydown', handler)
   }, [open, onClose])
 
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
+  const submitQuestion = () => {
     if (!questionText.trim()) return
     createQuestion.mutate({
       question: questionText.trim(),
@@ -465,6 +456,11 @@ function CreateQuestionModal({ open, onClose }: { open: boolean; onClose: () => 
     setContext('')
     setProjectSlug('')
     onClose()
+  }
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    submitQuestion()
   }
 
   if (!open) return null
@@ -498,15 +494,25 @@ function CreateQuestionModal({ open, onClose }: { open: boolean; onClose: () => 
             <label htmlFor="question-text" className="block text-xs font-medium mb-1" style={{ color: 'var(--slate)' }}>
               Question *
             </label>
-            <textarea
-              id="question-text"
+            {/* SmartCompose (D14) — @-mention dropdown surfaces @hermes
+                in the team list so a user typing the prefix gets a real
+                hint that AI assist is wired. Modal's own submit button
+                ("Ask the Lab") drives the form, so SmartCompose's button
+                is hidden via hideSubmitButton. Cmd+Enter still triggers
+                the modal's form-level handler via the keydown listener
+                in the focus-trap effect. */}
+            <SmartCompose
+              theme="light"
+              bare
               value={questionText}
-              onChange={(e) => setQuestionText(e.target.value)}
-              placeholder="What do you want to know?"
+              onChange={setQuestionText}
+              onSubmit={async () => submitQuestion()}
+              uploadContext={{ type: 'question', id: 'new', entityType: 'question' }}
+              placeholder="What do you want to know? (use @hermes for AI)"
               rows={3}
-              className="w-full rounded-md border px-3 py-2 text-sm outline-none resize-none"
-              style={{ borderColor: 'var(--border-subtle)' }}
-              aria-required="true"
+              alwaysShowToolbar
+              hideSubmitButton
+              hideKbdHint
               autoFocus
             />
           </div>

--- a/src/pages/portal/TodayPage.tsx
+++ b/src/pages/portal/TodayPage.tsx
@@ -32,6 +32,7 @@ import { PillStrip } from '../../components/today/PillStrip'
 import { RightNow } from '../../components/today/RightNowCard'
 import { Timeline } from '../../components/today/Timeline'
 import { TaskGroup } from '../../components/today/TaskGroup'
+import { MorningThoughtCompose } from '../../components/today/MorningThoughtCompose'
 import { HermesSuggestsCard } from '../../components/today/rail/HermesSuggestsCard'
 import { NeedsAttentionCard } from '../../components/today/rail/NeedsAttentionCard'
 import { ProjectsCard } from '../../components/today/rail/ProjectsCard'
@@ -234,13 +235,11 @@ export default function TodayPage() {
 
         <PillStrip counts={counts} />
 
-        <div style={{ display: 'flex', gap: 8, padding: '10px 14px', background: PANEL_BG, border: '1px solid rgba(255,255,255,0.08)', borderRadius: 6, marginBottom: 20 }}>
-          <span style={{ fontSize: 14 }}>🧠</span>
-          <input
-            placeholder="Morning thought, quick capture, or @hermes to delegate…"
-            style={{ flex: 1, background: 'transparent', border: 'none', fontSize: 13, color: INK, outline: 'none', fontFamily: 'inherit' }}
-          />
-          <kbd style={{ fontFamily: 'var(--font-mono), JetBrains Mono, monospace', fontSize: 10, padding: '2px 6px', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 3, color: INK_DIM }}>⌘ ⏎</kbd>
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8, padding: '10px 14px', background: PANEL_BG, border: '1px solid rgba(255,255,255,0.08)', borderRadius: 6, marginBottom: 20 }}>
+          <span style={{ fontSize: 14, marginTop: 2 }}>🧠</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <MorningThoughtCompose />
+          </div>
         </div>
 
         <RightNow task={rightNowTask} project={rightNowProject ? { name: rightNowProject.name, slug: rightNowProject.slug } : null} queueTasks={queueTasks} state={state} />


### PR DESCRIPTION
Wave 3 of audit/2026-04-28 fix phase. Phase A foundations PR per Decision D14. Build clean throughout.

## Closes (9 sites)

### Foundation
- **SmartCompose extension** — added optional `onSubmit`, `value`/`onChange`, `submitting`, `uploadContext` ('task' | 'project' | 'meeting' | 'question' | 'answer' | 'daily_thought' | 'note'), `theme='dark'\|'light'`, `bare`, `autoFocus`, `alwaysShowToolbar`, `submitLabel`/`submittingLabel`, `hideKbdHint`, `hideSubmitButton`, `rows`. Backward-compatible — 3 existing callers (TaskDetailDrawer, MyTasks InlineDetail, MyTasks TaskDrawer) unchanged. Paste-image now wired inside SmartCompose itself.

### Adoption sites
- **PD-6** ProjectDetail Overview compose — replaces `appendToCompose('@')`/`appendToCompose(':')` decorative buttons
- **PD-6 family** ProjectUpdateFeed — adopted SmartCompose; 4 type pills (progress/blocker/result/question/session) preserved as header row
- **PD-6 family** ProjectComments — adopted SmartCompose
- **MTG-02** MeetingDetail action items form — replaces `appendCh('@')`/`appendCh(':')`. **NLP quick-add preserved** (`parseQuickAddInput` runs on Cmd+Enter)
- **MTG-03** MeetingDetail notes editor — plain textarea → SmartCompose
- **ATL-05 part 1** AskTheLab question composer modal — bare textarea → SmartCompose w/ `hideSubmitButton` (modal already has Cmd+Enter)
- **ATL-05 part 2** AskTheLab answer form — bare textarea → SmartCompose
- **TP-01** TodayPage morning thought — new `MorningThoughtCompose` component (~110 lines) per D11 prefix-routed + time-aware:
  - `@hermes <text>` → `/api/ai-requests` w/ `source_type='daily_thought'`
  - `note: <text>` → `today_state_<day>.thoughts` LS array
  - default → `useCreateTask` w/ `group_override='priorities'`
  - After 5pm CT (`hour >= 17`): placeholder swaps + tasks default `due_date=tomorrow`
- **TP-02** TodayPage Right Now chat input — bare `<input>` → SmartCompose w/ `taskId`

## Pattern surprises

- SmartCompose was hardcoded to `usePostTaskUpdate(taskId)`. Couldn't drop into 7 of 9 sites without refactor → extended with custom-mode props. Backward-compatible.
- Hermes detection on meeting notes was speculative. Confirmed via grep that `api/routes/meetings.ts` has no `@hermes`/`@claude` regex (only `questions.ts` and `projects.ts`). Brief's 'leave that path alone' was a no-op.
- TP-01 routing required new component (`MorningThoughtCompose.tsx`) because of D11's prefix-routing + time-aware spec.
- Cleanup of `quickComposeFileInputRef` / `AtSign` / `Smile` / `Paperclip` imports intentional — SmartCompose has its own internal ref + uses lucide icons internally.
- Outer drag-drop wrapper preserved (different code path: appends markdown link via existing `uploadToCompose`, vs. SmartCompose's R2 flow which is ALSO wired). Both work; no conflict.
- AskTheLab modal width (`max-w-md`) intentionally left for separate fix per brief.

## Files

- `src/components/SmartCompose.tsx` (extended — backward compatible)
- `src/components/today/MorningThoughtCompose.tsx` (new for TP-01 D11)
- `src/pages/portal/TodayPage.tsx` (TP-01 wire)
- `src/components/today/RightNowCard.tsx` (TP-02)
- `src/pages/ProjectDetail.tsx` (PD-6, compose section only)
- `src/components/ProjectUpdateFeed.tsx`
- `src/components/ProjectComments.tsx`
- `src/pages/MeetingDetail.tsx` (MTG-02, MTG-03)
- `src/pages/portal/AskTheLab.tsx` (ATL-05)
- `audit/2026-04-28/progress-log.md`

## Verification

- `npm run build` clean (TypeScript + Vite) at every commit
- `tsc --noEmit -p tsconfig.app.json` clean
- All 9 sites verified STILL BROKEN against current source before fixing
- Rebased onto main (post-Bundle-D + post-Bundle-F merges); Paperclip/AtSign/Smile imports dropped via merge resolution since SmartCompose owns those