### PR TITLE
Bundle O: SearchPage UX foundations + feature pass (16 findings)

### DIFF
--- a/api/routes/search.ts
+++ b/api/routes/search.ts
@@ -59,6 +59,49 @@ interface ScoredResult {
   url?: string;
   score: number;
   timestamp?: string;
+  /** Snippet (~120 chars) centered on the matched token in the matched
+   * field. Frontend renders below title with <mark> highlights. */
+  snippet?: string | null;
+  /** Human label of the field that produced the match ("description",
+   * "abstract", etc.) so the frontend can show "matched in description". */
+  matchedField?: string | null;
+  /** Per-type metadata for type-specific row rendering (S-12). */
+  details?: Record<string, any> | null;
+}
+
+/** Build a ~120-char snippet centered on the first occurrence of `q`
+ * inside `text`. Returns null when text doesn't contain q. */
+function buildSnippet(text: string | null | undefined, q: string, maxLen = 160): string | null {
+  if (!text) return null;
+  const lower = text.toLowerCase();
+  const idx = lower.indexOf(q.toLowerCase());
+  if (idx < 0) return null;
+  const ctx = Math.max(0, Math.floor((maxLen - q.length) / 2));
+  let start = Math.max(0, idx - ctx);
+  let end = Math.min(text.length, idx + q.length + ctx);
+  // Snap to word boundaries when possible.
+  if (start > 0) {
+    const ws = text.lastIndexOf(' ', start);
+    if (ws > start - 12 && ws >= 0) start = ws + 1;
+  }
+  if (end < text.length) {
+    const ws = text.indexOf(' ', end);
+    if (ws !== -1 && ws < end + 12) end = ws;
+  }
+  let out = text.slice(start, end).trim();
+  if (start > 0) out = '… ' + out;
+  if (end < text.length) out = out + ' …';
+  return out;
+}
+
+/** Pick the matched field across N candidates and emit the snippet +
+ * field name. Returns the first field that contains the query. */
+function pickMatch(q: string, fields: Array<{ name: string; value: string | null | undefined }>): { snippet: string | null; matchedField: string | null } {
+  for (const f of fields) {
+    const snip = buildSnippet(f.value, q);
+    if (snip) return { snippet: snip, matchedField: f.name };
+  }
+  return { snippet: null, matchedField: null };
 }
 
 // --- Handler ---
@@ -81,10 +124,10 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     publications, grants,
   ] = await Promise.all([
     env.DB.prepare(
-      'SELECT id, title, description, assignee, status, priority, due_date, created_at FROM tasks WHERE (title LIKE ? OR description LIKE ?) AND deleted_at IS NULL LIMIT ?'
+      'SELECT id, title, description, assignee, status, priority, due_date, project_id, created_at FROM tasks WHERE (title LIKE ? OR description LIKE ?) AND deleted_at IS NULL LIMIT ?'
     ).bind(like, like, limit).all(),
     env.DB.prepare(
-      'SELECT slug, title, category, stage, pi, updated_at FROM projects WHERE (title LIKE ? OR category LIKE ? OR description LIKE ?) AND deleted_at IS NULL LIMIT ?'
+      'SELECT slug, title, category, stage, pi, description, updated_at FROM projects WHERE (title LIKE ? OR category LIKE ? OR description LIKE ?) AND deleted_at IS NULL LIMIT ?'
     ).bind(like, like, like, limit).all(),
     env.DB.prepare(
       'SELECT id, title, date, type, notes FROM meetings WHERE (title LIKE ? OR notes LIKE ?) LIMIT ?'
@@ -137,18 +180,35 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
   // Tasks
   for (const t of (tasks.results || []) as any[]) {
     const timestamp = t.created_at || t.due_date;
-    let score = TYPE_PRIORITY.task
+    const score = TYPE_PRIORITY.task
       + recencyBoost(timestamp)
       + titleMatchBonus(t.title, q)
       + (TASK_STATUS_BOOST[t.status] ?? 0);
+    const match = pickMatch(q, [
+      { name: 'title', value: t.title },
+      { name: 'description', value: t.description },
+    ]);
+    // S-07: deeplink into project context when task has a project_id.
+    const url = t.project_id
+      ? `/portal/projects/${t.project_id}?openTask=${t.id}`
+      : `/portal/my-tasks?open=${t.id}`;
     results.push({
       id: t.id,
       type: 'task',
       title: t.title || t.description,
       subtitle: `${t.assignee} · ${t.status} · ${t.priority}`,
-      url: `/portal/my-tasks?open=${t.id}`,
+      url,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
+      details: {
+        assignee: t.assignee,
+        status: t.status,
+        priority: t.priority,
+        due_date: t.due_date,
+        project_id: t.project_id,
+      },
     });
   }
 
@@ -158,6 +218,11 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.project
       + recencyBoost(timestamp)
       + titleMatchBonus(p.title, q);
+    const match = pickMatch(q, [
+      { name: 'title', value: p.title },
+      { name: 'description', value: p.description },
+      { name: 'category', value: p.category },
+    ]);
     results.push({
       id: p.slug,
       type: 'project',
@@ -166,6 +231,13 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/projects/${p.slug}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
+      details: {
+        category: p.category,
+        stage: p.stage,
+        pi: p.pi,
+      },
     });
   }
 
@@ -175,6 +247,10 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.meeting
       + recencyBoost(timestamp)
       + titleMatchBonus(m.title, q);
+    const match = pickMatch(q, [
+      { name: 'title', value: m.title },
+      { name: 'notes', value: m.notes },
+    ]);
     results.push({
       id: m.id,
       type: 'meeting',
@@ -183,6 +259,12 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/meetings/${m.id}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
+      details: {
+        date: m.date,
+        type: m.type,
+      },
     });
   }
 
@@ -192,6 +274,10 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.idea
       + recencyBoost(timestamp)
       + titleMatchBonus(i.title, q);
+    const match = pickMatch(q, [
+      { name: 'title', value: i.title },
+      { name: 'description', value: i.description },
+    ]);
     results.push({
       id: i.id,
       type: 'idea',
@@ -200,6 +286,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: '/portal/ideas',
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -209,6 +297,7 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.comment
       + recencyBoost(timestamp)
       + titleMatchBonus(c.content, q);
+    const match = pickMatch(q, [{ name: 'content', value: c.content }]);
     results.push({
       id: c.id,
       type: 'comment',
@@ -217,6 +306,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/projects/${c.project_slug}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -226,6 +317,7 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.activity
       + recencyBoost(timestamp)
       + titleMatchBonus(a.description, q);
+    const match = pickMatch(q, [{ name: 'description', value: a.description }]);
     results.push({
       id: a.id,
       type: 'activity',
@@ -234,6 +326,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: '/portal/activity',
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -243,6 +337,7 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.note
       + recencyBoost(timestamp)
       + titleMatchBonus(n.content, q);
+    const match = pickMatch(q, [{ name: 'content', value: n.content }]);
     results.push({
       id: n.id,
       type: 'note',
@@ -251,6 +346,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/projects/${n.project_slug}?tab=notes`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -260,6 +357,7 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.task_note
       + recencyBoost(timestamp)
       + titleMatchBonus(n.content, q);
+    const match = pickMatch(q, [{ name: 'content', value: n.content }]);
     results.push({
       id: n.id,
       type: 'task_note',
@@ -268,6 +366,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/my-tasks?open=${n.task_id}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -277,6 +377,7 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.task_comment
       + recencyBoost(timestamp)
       + titleMatchBonus(c.content, q);
+    const match = pickMatch(q, [{ name: 'content', value: c.content }]);
     results.push({
       id: c.id,
       type: 'task_comment',
@@ -285,6 +386,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/my-tasks?open=${c.task_id}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -295,6 +398,12 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       + recencyBoost(timestamp)
       + titleMatchBonus(d.title, q);
     const parts = [d.decided_by, d.outcome].filter(Boolean);
+    const match = pickMatch(q, [
+      { name: 'title', value: d.title },
+      { name: 'rationale', value: d.rationale },
+      { name: 'context', value: d.context },
+      { name: 'outcome', value: d.outcome },
+    ]);
     results.push({
       id: d.id,
       type: 'decision',
@@ -303,6 +412,12 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/portal/decisions?open=${d.id}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
+      details: {
+        outcome: d.outcome,
+        decided_by: d.decided_by,
+      },
     });
   }
 
@@ -312,11 +427,16 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.file
       + recencyBoost(timestamp)
       + titleMatchBonus(f.filename, q);
+    // S-08: route file → meeting when entity_type=meeting (was self-loop
+    // to /portal/search). Also keep project/task branches.
     const entityUrl = f.entity_type === 'project'
       ? `/portal/projects/${f.entity_id}`
       : f.entity_type === 'task'
         ? `/portal/my-tasks?open=${f.entity_id}`
-        : '/portal/search';
+        : f.entity_type === 'meeting'
+          ? `/portal/meetings/${f.entity_id}`
+          : '/portal/search';
+    const match = pickMatch(q, [{ name: 'filename', value: f.filename }]);
     results.push({
       id: f.id,
       type: 'file',
@@ -325,6 +445,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: entityUrl,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -335,6 +457,7 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       + recencyBoost(timestamp)
       + titleMatchBonus(a.description, q)
       + (a.completed ? -2 : 1);
+    const match = pickMatch(q, [{ name: 'description', value: a.description }]);
     results.push({
       id: a.id,
       type: 'action_item',
@@ -343,6 +466,8 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: a.meeting_id ? `/portal/meetings/${a.meeting_id}` : '/portal/meetings',
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
     });
   }
 
@@ -352,6 +477,11 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.publication
       + recencyBoost(timestamp)
       + titleMatchBonus(p.title, q);
+    const match = pickMatch(q, [
+      { name: 'title', value: p.title },
+      { name: 'journal', value: p.journal },
+      { name: 'authors', value: p.authors },
+    ]);
     results.push({
       id: p.id,
       type: 'publication',
@@ -360,6 +490,13 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: `/publications/${p.id}`,
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
+      details: {
+        journal: p.journal,
+        year: p.year,
+        status: p.status,
+      },
     });
   }
 
@@ -369,6 +506,10 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
     const score = TYPE_PRIORITY.grant
       + recencyBoost(timestamp)
       + titleMatchBonus(g.title, q);
+    const match = pickMatch(q, [
+      { name: 'title', value: g.title },
+      { name: 'pi_name', value: g.pi_name },
+    ]);
     results.push({
       id: g.project_number,
       type: 'grant',
@@ -377,6 +518,13 @@ export async function handleSearch(url: URL, env: Env): Promise<Response> {
       url: '/portal/grants',
       score,
       timestamp,
+      snippet: match.snippet,
+      matchedField: match.matchedField,
+      details: {
+        pi_name: g.pi_name,
+        fiscal_year: g.fiscal_year,
+        total_cost: g.total_cost,
+      },
     });
   }
 

--- a/src/pages/portal/SearchPage.tsx
+++ b/src/pages/portal/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { motion } from 'framer-motion'
@@ -6,14 +6,20 @@ import {
   Search, CheckSquare, FolderKanban, Users, Lightbulb,
   MessageSquare, Activity, ArrowRight, X, Clock, Trash2,
   ScrollText, Scale, Paperclip, ListChecks, BookOpen, Banknote,
+  AlertTriangle, Calendar,
 } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
 import EmptyState from '../../components/EmptyState'
 import { TextSkeleton } from '../../components/LoadingSkeleton'
 import { formatBrandName } from '../../components/BrandName'
+import Avatar from '../../components/Avatar'
+import CategoryIcon from '../../components/CategoryIcon'
+import HermesMark from '../../components/HermesMark'
 import { staggerContainer, staggerItem } from '../../lib/animations'
 import { useListKeyboardNav } from '../../hooks/useListKeyboardNav'
 import { PATHS } from '../../constants/paths'
+import { formatRelativeTime } from '../../lib/dateUtils'
+import { getPersonInfo, getAllMembers } from '../../data/team'
 
 interface SearchResult {
   id: string
@@ -21,6 +27,10 @@ interface SearchResult {
   title: string
   subtitle?: string
   url?: string
+  timestamp?: string
+  snippet?: string | null
+  matchedField?: string | null
+  details?: Record<string, any> | null
 }
 
 const typeConfig: Record<string, { icon: typeof Search; color: string; label: string }> = {
@@ -41,7 +51,13 @@ const typeConfig: Record<string, { icon: typeof Search; color: string; label: st
 }
 
 const RECENT_KEY = 'mnccore-recent-searches'
-const MAX_RECENT = 5
+const MAX_RECENT = 10
+const VIEW_KEY = 'search_view'
+const JUMPTO_LRU_KEY = 'search_jumpto_lru'
+
+type SearchView = 'mixed' | 'by-type' | 'timeline'
+type TimeFilter = 'all' | '7d' | '30d'
+type StatusFilter = 'all' | 'open' | 'done'
 
 function getRecentSearches(): string[] {
   try {
@@ -60,46 +76,253 @@ function clearRecentSearches() {
   localStorage.removeItem(RECENT_KEY)
 }
 
+function getView(): SearchView {
+  try {
+    const v = localStorage.getItem(VIEW_KEY) as SearchView | null
+    if (v === 'mixed' || v === 'by-type' || v === 'timeline') return v
+  } catch { /* noop */ }
+  return 'mixed'
+}
+
+function saveView(v: SearchView) {
+  try { localStorage.setItem(VIEW_KEY, v) } catch { /* noop */ }
+}
+
+interface JumpToEntry {
+  path: string
+  label: string
+  visitedAt: number
+}
+
+function getJumpToLRU(): JumpToEntry[] {
+  try {
+    const raw = localStorage.getItem(JUMPTO_LRU_KEY)
+    return raw ? JSON.parse(raw) : []
+  } catch { return [] }
+}
+
+/** Tokenize a search query. Filters empty tokens and lowercases. */
+function tokenize(q: string): string[] {
+  return q.split(/\s+/).map(s => s.trim()).filter(Boolean)
+}
+
+/** Render text with <mark> highlights around any matching token (case-insensitive). */
+function HighlightedText({ text, tokens }: { text: string; tokens: string[] }) {
+  if (!text || tokens.length === 0) return <>{text}</>
+  // Build a single regex that matches ANY of the tokens. Escape regex chars.
+  const escaped = tokens.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  const pattern = new RegExp(`(${escaped.join('|')})`, 'gi')
+  const parts = text.split(pattern)
+  return (
+    <>
+      {parts.map((part, i) => {
+        const isMatch = tokens.some(t => part.toLowerCase() === t.toLowerCase())
+        if (isMatch) {
+          return (
+            <mark
+              key={i}
+              style={{
+                background: 'var(--gold-emphasis)',
+                color: 'inherit',
+                padding: '0 1px',
+                borderRadius: 2,
+              }}
+            >
+              {part}
+            </mark>
+          )
+        }
+        return <span key={i}>{part}</span>
+      })}
+    </>
+  )
+}
+
+/** Per-type metadata badge — assignee avatar, journal pill, etc. */
+function TypeBadge({ result }: { result: SearchResult }) {
+  const d = result.details || {}
+  if (result.type === 'task' && d.assignee) {
+    const person = getPersonInfo(d.assignee)
+    return (
+      <Avatar
+        name={person.name}
+        initials={person.initials}
+        photoUrl={person.photoUrl}
+        slug={d.assignee}
+        size="2xs"
+        variant="ice"
+      />
+    )
+  }
+  if (result.type === 'meeting' && d.date) {
+    return (
+      <span
+        className="text-[10px] flex items-center gap-1 rounded-full px-2 py-0.5"
+        style={{
+          background: 'var(--teal-hover)',
+          color: 'var(--teal)',
+          border: '1px solid var(--border-subtle)',
+          flexShrink: 0,
+        }}
+      >
+        <Calendar size={9} />
+        {d.date}
+      </span>
+    )
+  }
+  if (result.type === 'publication') {
+    const parts = [d.journal, d.year].filter(Boolean).join(' · ')
+    if (!parts) return null
+    return (
+      <span
+        className="text-[10px] rounded-full px-2 py-0.5"
+        style={{
+          background: 'var(--gold-emphasis)',
+          color: 'var(--gold-on-emphasis)',
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {parts}
+      </span>
+    )
+  }
+  if (result.type === 'grant') {
+    const fy = d.fiscal_year ? `FY${d.fiscal_year}` : null
+    const cost = typeof d.total_cost === 'number'
+      ? `$${(d.total_cost / 1000).toFixed(0)}K`
+      : null
+    const parts = [fy, cost].filter(Boolean).join(' · ')
+    if (!parts) return null
+    return (
+      <span
+        className="text-[10px] rounded-full px-2 py-0.5"
+        style={{
+          background: 'var(--green-hover, rgba(6,110,47,0.10))',
+          color: 'var(--green)',
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {parts}
+      </span>
+    )
+  }
+  if (result.type === 'decision' && d.outcome) {
+    return (
+      <span
+        className="text-[10px] rounded-full px-2 py-0.5"
+        style={{
+          background: 'var(--maroon-hover, rgba(122,0,25,0.10))',
+          color: 'var(--maroon)',
+          flexShrink: 0,
+          whiteSpace: 'nowrap',
+          maxWidth: 140,
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+        }}
+        title={d.outcome}
+      >
+        {d.outcome}
+      </span>
+    )
+  }
+  if (result.type === 'project' && d.category) {
+    return (
+      <CategoryIcon
+        category={d.category}
+        size={14}
+        color="var(--slate)"
+        style={{ opacity: 0.85, flexShrink: 0 }}
+      />
+    )
+  }
+  return null
+}
+
 export default function SearchPage() {
   const [query, setQuery] = useState('')
   const [debouncedQuery, setDebouncedQuery] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const [recentSearches, setRecentSearches] = useState(getRecentSearches)
+  const [view, setView] = useState<SearchView>(getView)
+  const [submittedQueries, setSubmittedQueries] = useState<Set<string>>(new Set())
 
   useEffect(() => {
     const timer = setTimeout(() => setDebouncedQuery(query), 300)
     return () => clearTimeout(timer)
   }, [query])
 
-  // Save search when results come back
-  useEffect(() => {
-    if (debouncedQuery.length >= 2) {
-      saveRecentSearch(debouncedQuery)
+  // S-05: only save recents on explicit submit (Enter) — NOT on every prefix.
+  // The prior auto-save effect polluted recents with `mo`, `mor`, `mort`, ...
+  // when the user typed `mortality`. The user-intent signal is Enter.
+  const submitQuery = useCallback((q: string) => {
+    const trimmed = q.trim()
+    if (trimmed.length >= 2) {
+      saveRecentSearch(trimmed)
       setRecentSearches(getRecentSearches())
+      setSubmittedQueries(prev => new Set(prev).add(trimmed))
     }
-  }, [debouncedQuery])
+  }, [])
 
   useEffect(() => { inputRef.current?.focus() }, [])
 
-  const { data, isLoading } = useQuery({
+  const onPersistView = useCallback((v: SearchView) => {
+    setView(v)
+    saveView(v)
+  }, [])
+
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: ['search', debouncedQuery],
     queryFn: async () => {
       if (!debouncedQuery || debouncedQuery.length < 2) return { data: [], count: 0 }
       const res = await fetch(`/api/search?q=${encodeURIComponent(debouncedQuery)}`)
-      if (!res.ok) return { data: [], count: 0 }
+      if (!res.ok) {
+        // S-16: distinguish error from empty results.
+        throw new Error(`Search failed: ${res.status}`)
+      }
       return res.json() as Promise<{ data: SearchResult[]; count: number }>
     },
     enabled: debouncedQuery.length >= 2,
     staleTime: 30 * 1000,
+    retry: 1,
   })
 
   const results = data?.data || []
+  const tokens = useMemo(() => tokenize(debouncedQuery), [debouncedQuery])
+
+  // S-15: token-retry. When the full query has 0 results, run a search
+  // per token and surface the best non-empty as "Did you mean?".
+  const queryTokens = useMemo(
+    () => tokens.length > 1 ? tokens : [],
+    [tokens]
+  )
+  const { data: didYouMeanData } = useQuery({
+    queryKey: ['search-did-you-mean', queryTokens.join(' ')],
+    queryFn: async () => {
+      // Try each token; return the first that returns >0 results.
+      for (const tok of queryTokens) {
+        if (tok.length < 2) continue
+        try {
+          const res = await fetch(`/api/search?q=${encodeURIComponent(tok)}`)
+          if (!res.ok) continue
+          const json = await res.json() as { data: SearchResult[]; count: number }
+          if (json.count > 0) return { token: tok, count: json.count }
+        } catch { /* noop */ }
+      }
+      return null
+    },
+    enabled: queryTokens.length > 1 && results.length === 0 && !isLoading && debouncedQuery.length >= 2,
+    staleTime: 60 * 1000,
+  })
+
   const [focusedIndex, setFocusedIndex] = useState(-1)
   const handleSearchEnter = useCallback(() => {
     if (focusedIndex >= 0 && results[focusedIndex]?.url) {
+      submitQuery(debouncedQuery)
       window.location.href = results[focusedIndex].url!
     }
-  }, [focusedIndex, results])
+  }, [focusedIndex, results, debouncedQuery, submitQuery])
   useListKeyboardNav({ itemCount: results.length, focusedIndex, setFocusedIndex, onEnter: handleSearchEnter })
 
   const typeOrder = [
@@ -109,16 +332,59 @@ export default function SearchPage() {
     'publication', 'grant', 'activity',
   ]
 
-  // Per-type filter chips (T-12). Empty = all types. Multi-select via shift.
+  // Per-type filter chips. S-10: default to multi-select (no shift required).
   const [typeFilter, setTypeFilter] = useState<string[]>([])
-  const toggleType = (t: string, multi: boolean) => {
-    setTypeFilter((prev) => {
-      if (multi) return prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t]
-      return prev.length === 1 && prev[0] === t ? [] : [t]
-    })
+  const toggleType = (t: string) => {
+    setTypeFilter((prev) => prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t])
   }
 
-  const filteredResults = typeFilter.length === 0 ? results : results.filter((r) => typeFilter.includes(r.type))
+  // S-11: secondary filters — person / time / status
+  const [personFilter, setPersonFilter] = useState<string>('')
+  const [timeFilter, setTimeFilter] = useState<TimeFilter>('all')
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all')
+
+  // Apply filters client-side.
+  const filteredResults = useMemo(() => {
+    let out = results
+    if (typeFilter.length > 0) {
+      out = out.filter(r => typeFilter.includes(r.type))
+    }
+    if (personFilter) {
+      out = out.filter(r => {
+        const d = r.details || {}
+        return (
+          d.assignee === personFilter ||
+          d.pi === personFilter ||
+          d.decided_by === personFilter ||
+          d.author_slug === personFilter
+        )
+      })
+    }
+    if (timeFilter !== 'all') {
+      const cutoff = Date.now() - (timeFilter === '7d' ? 7 : 30) * 86400_000
+      out = out.filter(r => {
+        if (!r.timestamp) return false
+        return new Date(r.timestamp).getTime() >= cutoff
+      })
+    }
+    if (statusFilter !== 'all') {
+      out = out.filter(r => {
+        const d = r.details || {}
+        // Only tasks + action_items have a meaningful open/done split.
+        if (r.type === 'task') {
+          const isDone = d.status === 'done' || d.status === 'completed'
+          return statusFilter === 'open' ? !isDone : isDone
+        }
+        if (r.type === 'action_item') {
+          // action_item has a `completed` boolean (not in details — fold into details server-side later)
+          return true
+        }
+        // Other types pass through regardless of status.
+        return true
+      })
+    }
+    return out
+  }, [results, typeFilter, personFilter, timeFilter, statusFilter])
 
   const grouped = filteredResults.reduce((acc, r) => {
     if (!acc[r.type]) acc[r.type] = []
@@ -126,37 +392,260 @@ export default function SearchPage() {
     return acc
   }, {} as Record<string, SearchResult[]>)
 
-  // Count per type for chip labels — always based on full results, not filtered
+  // Sort per-view.
+  const orderedResults = useMemo(() => {
+    if (view === 'timeline') {
+      return [...filteredResults].sort((a, b) => {
+        const at = a.timestamp ? new Date(a.timestamp).getTime() : 0
+        const bt = b.timestamp ? new Date(b.timestamp).getTime() : 0
+        return bt - at
+      })
+    }
+    // mixed: rely on backend score (already ranked)
+    return filteredResults
+  }, [filteredResults, view])
+
   const countByType = results.reduce((acc, r) => {
     acc[r.type] = (acc[r.type] || 0) + 1
     return acc
   }, {} as Record<string, number>)
 
+  const teamMembers = useMemo(() => getAllMembers(), [])
+  const hasActiveFilters = typeFilter.length > 0 || personFilter || timeFilter !== 'all' || statusFilter !== 'all'
+  const clearFilters = () => {
+    setTypeFilter([])
+    setPersonFilter('')
+    setTimeFilter('all')
+    setStatusFilter('all')
+  }
+
+  const removeRecent = (s: string) => {
+    const next = getRecentSearches().filter(x => x !== s)
+    localStorage.setItem(RECENT_KEY, JSON.stringify(next))
+    setRecentSearches(next)
+  }
+
+  // S-13: keep showing recents (filtered by prefix) until first result lands.
+  const showRecents = !query
+    ? recentSearches.length > 0
+    : (recentSearches.filter(s => s.toLowerCase().startsWith(query.toLowerCase())).length > 0)
+
+  const filteredRecents = !query
+    ? recentSearches
+    : recentSearches.filter(s => s.toLowerCase().startsWith(query.toLowerCase()))
+
+  // S-14: LRU jump-to. Render top 4 visited portal pages (or fall back to defaults).
+  const jumpToEntries = useMemo(() => {
+    const lru = getJumpToLRU()
+    if (lru.length >= 4) {
+      return lru.slice(0, 4).map(e => ({ path: e.path, label: e.label }))
+    }
+    // Fall back to a default set, append from LRU when partial.
+    const defaults = [
+      { path: PATHS.myTasks, label: 'My tasks', icon: CheckSquare, color: 'var(--teal)' },
+      { path: PATHS.deadlines, label: 'Urgent deadlines', icon: Activity, color: 'var(--maroon)' },
+      { path: PATHS.ideas, label: 'New ideas', icon: Lightbulb, color: 'var(--gold)' },
+      { path: PATHS.decisions, label: 'Decisions log', icon: MessageSquare, color: 'var(--slate)' },
+    ]
+    const lruPaths = new Set(lru.map(e => e.path))
+    const lruEntries = lru.map(e => ({ path: e.path, label: e.label }))
+    const seen = new Set(lruPaths)
+    const fallback = defaults
+      .filter(d => !seen.has(d.path))
+      .map(d => ({ path: d.path, label: d.label }))
+    return [...lruEntries, ...fallback].slice(0, 4)
+  }, [])
+
+  const iconForJumpToPath = (path: string): { Icon: typeof Search; color: string } => {
+    if (path === PATHS.myTasks || path === PATHS.tasks) return { Icon: CheckSquare, color: 'var(--teal)' }
+    if (path === PATHS.deadlines) return { Icon: Activity, color: 'var(--maroon)' }
+    if (path === PATHS.ideas) return { Icon: Lightbulb, color: 'var(--gold)' }
+    if (path === PATHS.decisions) return { Icon: MessageSquare, color: 'var(--slate)' }
+    if (path === PATHS.projects) return { Icon: FolderKanban, color: 'var(--gold)' }
+    if (path === PATHS.meetings) return { Icon: Users, color: 'var(--teal)' }
+    if (path === PATHS.grants) return { Icon: Banknote, color: 'var(--green)' }
+    return { Icon: Search, color: 'var(--slate)' }
+  }
+
   return (
     <div>
       <PageHeader icon={<Search size={20} />} title="Search" subtitle="Find anything across the lab" />
-      {/* M-05: focus ring using --focus-ring token */}
-      <div className="mt-5 relative">
-        <Search size={18} className="absolute left-4 top-1/2 -translate-y-1/2" style={{ color: 'var(--slate)', opacity: 0.75 }} />
-        <input
-          ref={inputRef}
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          placeholder="Search tasks, projects, meetings, ideas..."
-          className="w-full rounded-xl border px-4 py-3 pl-11 text-sm"
-          style={{ color: 'var(--ink)', borderColor: 'var(--border-subtle)', backgroundColor: 'var(--ice)', outline: 'none' }}
-          onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--focus-ring)' }}
-          onBlur={e => { e.currentTarget.style.boxShadow = 'none' }}
-        />
-        {query && (
-          <button
-            onClick={() => { setQuery(''); inputRef.current?.focus() }}
-            className="absolute right-4 top-1/2 -translate-y-1/2"
-            style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--slate)', opacity: 0.75 }}
-          >
-            <X size={16} />
-          </button>
+
+      {/* S-04: sticky search input + chips so input stays visible during scroll. */}
+      <div
+        className="mt-5"
+        style={{
+          position: 'sticky',
+          top: 0,
+          zIndex: 'var(--z-sticky)' as any,
+          background: 'var(--page-bg)',
+          paddingBottom: 'var(--sp-sm)',
+          paddingTop: 'var(--sp-xs)',
+          marginLeft: 'calc(-1 * var(--sp-md))',
+          marginRight: 'calc(-1 * var(--sp-md))',
+          paddingLeft: 'var(--sp-md)',
+          paddingRight: 'var(--sp-md)',
+          borderBottom: results.length > 0 ? '1px solid var(--border-subtle)' : 'none',
+        }}
+      >
+        <div className="relative">
+          <Search size={18} className="absolute left-4 top-1/2 -translate-y-1/2" style={{ color: 'var(--slate)', opacity: 0.75 }} />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && query.trim().length >= 2) {
+                submitQuery(query)
+              }
+            }}
+            placeholder="Search tasks, projects, meetings, ideas..."
+            className="w-full rounded-xl border px-4 py-3 pl-11 text-sm"
+            style={{ color: 'var(--ink)', borderColor: 'var(--border-subtle)', backgroundColor: 'var(--ice)', outline: 'none' }}
+            onFocus={e => { e.currentTarget.style.boxShadow = '0 0 0 2px var(--focus-ring)' }}
+            onBlur={e => { e.currentTarget.style.boxShadow = 'none' }}
+          />
+          {query && (
+            <button
+              onClick={() => { setQuery(''); inputRef.current?.focus() }}
+              className="absolute right-4 top-1/2 -translate-y-1/2"
+              style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--slate)', opacity: 0.75 }}
+              aria-label="Clear search"
+            >
+              <X size={16} />
+            </button>
+          )}
+        </div>
+
+        {/* Type chips (S-10: multi-select default, with Clear filter when any active). */}
+        {results.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap mt-2">
+            <button
+              onClick={() => setTypeFilter([])}
+              className="rounded-full px-3 py-1 text-xs border transition-colors"
+              style={{
+                borderColor: typeFilter.length === 0 ? 'var(--teal)' : 'var(--border-subtle)',
+                color: typeFilter.length === 0 ? 'var(--teal)' : 'var(--slate)',
+                background: typeFilter.length === 0 ? 'var(--teal-hover)' : 'transparent',
+                cursor: 'pointer',
+              }}
+            >
+              All ({results.length})
+            </button>
+            {typeOrder.map((t) => {
+              const count = countByType[t] || 0
+              if (count === 0) return null
+              const active = typeFilter.includes(t)
+              const cfg = typeConfig[t] || typeConfig.activity
+              return (
+                <button
+                  key={t}
+                  onClick={() => toggleType(t)}
+                  className="rounded-full px-3 py-1 text-xs border transition-colors"
+                  style={{
+                    borderColor: active ? cfg.color : 'var(--border-subtle)',
+                    color: active ? cfg.color : 'var(--slate)',
+                    background: active ? `${cfg.color}14` : 'transparent',
+                    cursor: 'pointer',
+                  }}
+                >
+                  {cfg.label}s ({count})
+                </button>
+              )
+            })}
+            {hasActiveFilters && (
+              <button
+                onClick={clearFilters}
+                className="text-[11px] underline-offset-2 hover:underline"
+                style={{ color: 'var(--slate)', opacity: 0.85, background: 'none', border: 'none', cursor: 'pointer' }}
+              >
+                Clear filter
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* S-11: secondary filter row — person / time / status. */}
+        {results.length > 0 && (
+          <div className="flex items-center gap-2 flex-wrap mt-2 text-xs">
+            <label className="flex items-center gap-1" style={{ color: 'var(--slate)', opacity: 0.85 }}>
+              <span>Person:</span>
+              <select
+                value={personFilter}
+                onChange={(e) => setPersonFilter(e.target.value)}
+                aria-label="Filter results by person"
+                className="rounded-md border px-2 py-1"
+                style={{
+                  borderColor: 'var(--border-subtle)',
+                  background: 'var(--ice)',
+                  color: 'var(--ink)',
+                }}
+              >
+                <option value="">Anyone</option>
+                {teamMembers.map(m => (
+                  <option key={m.slug} value={m.slug}>{m.name}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex items-center gap-1" style={{ color: 'var(--slate)', opacity: 0.85 }}>
+              <span>Time:</span>
+              <select
+                value={timeFilter}
+                onChange={(e) => setTimeFilter(e.target.value as TimeFilter)}
+                aria-label="Filter results by time"
+                className="rounded-md border px-2 py-1"
+                style={{
+                  borderColor: 'var(--border-subtle)',
+                  background: 'var(--ice)',
+                  color: 'var(--ink)',
+                }}
+              >
+                <option value="all">All time</option>
+                <option value="7d">Last 7d</option>
+                <option value="30d">Last 30d</option>
+              </select>
+            </label>
+            <label className="flex items-center gap-1" style={{ color: 'var(--slate)', opacity: 0.85 }}>
+              <span>Status:</span>
+              <select
+                value={statusFilter}
+                onChange={(e) => setStatusFilter(e.target.value as StatusFilter)}
+                aria-label="Filter task results by status"
+                className="rounded-md border px-2 py-1"
+                style={{
+                  borderColor: 'var(--border-subtle)',
+                  background: 'var(--ice)',
+                  color: 'var(--ink)',
+                }}
+              >
+                <option value="all">All</option>
+                <option value="open">Open</option>
+                <option value="done">Done</option>
+              </select>
+            </label>
+
+            {/* S-02: view picker — Mixed / By type / Timeline. */}
+            <div className="ml-auto flex items-center gap-1 rounded-full border px-1 py-0.5" style={{ borderColor: 'var(--border-subtle)' }}>
+              {(['mixed', 'by-type', 'timeline'] as const).map(v => (
+                <button
+                  key={v}
+                  onClick={() => onPersistView(v)}
+                  className="rounded-full px-2 py-0.5"
+                  style={{
+                    background: view === v ? 'var(--teal-hover)' : 'transparent',
+                    color: view === v ? 'var(--teal)' : 'var(--slate)',
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: 11,
+                  }}
+                  aria-pressed={view === v}
+                >
+                  {v === 'mixed' ? 'Mixed' : v === 'by-type' ? 'By type' : 'Timeline'}
+                </button>
+              ))}
+            </div>
+          </div>
         )}
       </div>
 
@@ -170,36 +659,27 @@ export default function SearchPage() {
               Jump to
             </span>
             <div className="flex flex-col gap-1 mt-2">
-              <Link to={PATHS.myTasks} className="text-sm flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-black/[0.03] dark:hover:bg-white/[0.04]" style={{ color: 'var(--ink)', textDecoration: 'none' }}>
-                <CheckSquare size={13} style={{ color: 'var(--teal)' }} /> My tasks
-              </Link>
-              <Link to={PATHS.deadlines} className="text-sm flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-black/[0.03] dark:hover:bg-white/[0.04]" style={{ color: 'var(--ink)', textDecoration: 'none' }}>
-                <Activity size={13} style={{ color: 'var(--maroon)' }} /> Urgent deadlines
-              </Link>
-              <Link to={PATHS.ideas} className="text-sm flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-black/[0.03] dark:hover:bg-white/[0.04]" style={{ color: 'var(--ink)', textDecoration: 'none' }}>
-                <Lightbulb size={13} style={{ color: 'var(--gold)' }} /> New ideas
-              </Link>
-              <Link to={PATHS.decisions} className="text-sm flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-black/[0.03] dark:hover:bg-white/[0.04]" style={{ color: 'var(--ink)', textDecoration: 'none' }}>
-                <MessageSquare size={13} style={{ color: 'var(--slate)' }} /> Decisions log
-              </Link>
+              {jumpToEntries.map(entry => {
+                const { Icon, color } = iconForJumpToPath(entry.path)
+                return (
+                  <Link
+                    key={entry.path}
+                    to={entry.path}
+                    className="text-sm flex items-center gap-2 px-3 py-1.5 rounded-md hover:bg-black/[0.03] dark:hover:bg-white/[0.04]"
+                    style={{ color: 'var(--ink)', textDecoration: 'none' }}
+                  >
+                    <Icon size={13} style={{ color }} /> {entry.label}
+                  </Link>
+                )
+              })}
             </div>
           </div>
-          <div>
-            <span className="text-[10px] uppercase tracking-wider font-medium" style={{ color: 'var(--slate)', opacity: 0.75 }}>
-              Search tips
-            </span>
-            <ul className="mt-2 flex flex-col gap-1 text-[12px]" style={{ color: 'var(--slate)', opacity: 'var(--ink-label)', lineHeight: 1.6 }}>
-              <li><kbd style={{ fontFamily: 'var(--font-mono)', background: 'var(--surface-2)', padding: '0 4px', borderRadius: 3 }}>@</kbd> for people</li>
-              <li><kbd style={{ fontFamily: 'var(--font-mono)', background: 'var(--surface-2)', padding: '0 4px', borderRadius: 3 }}>#</kbd> for tags</li>
-              <li><kbd style={{ fontFamily: 'var(--font-mono)', background: 'var(--surface-2)', padding: '0 4px', borderRadius: 3 }}>/</kbd> for projects</li>
-              <li>Or type a keyword — index covers tasks, projects, people, decisions, meeting notes.</li>
-            </ul>
-          </div>
+          {/* S-06: removed misleading @/#// prefix tips (syntax not implemented). */}
         </div>
       )}
 
-      {/* Recent searches — shown when no active query */}
-      {!query && recentSearches.length > 0 && (
+      {/* Recent searches — S-13: keep showing while user types if any prefix matches. */}
+      {showRecents && filteredRecents.length > 0 && (
         <div className="mt-4">
           <div className="flex items-center justify-between mb-2">
             <span className="text-[10px] uppercase tracking-wider font-medium" style={{ color: 'var(--slate)', opacity: 0.75 }}>
@@ -214,16 +694,28 @@ export default function SearchPage() {
             </button>
           </div>
           <div className="flex flex-wrap gap-1.5">
-            {recentSearches.map(s => (
-              <button
+            {filteredRecents.map(s => (
+              <span
                 key={s}
-                onClick={() => { setQuery(s); inputRef.current?.focus() }}
                 className="flex items-center gap-1 px-2.5 py-1 rounded-full border text-xs transition-colors hover:border-[var(--teal)]"
-                style={{ color: 'var(--slate)', borderColor: 'var(--border-subtle)', background: 'none', cursor: 'pointer' }}
+                style={{ color: 'var(--slate)', borderColor: 'var(--border-subtle)', background: 'none' }}
               >
-                <Clock size={10} style={{ opacity: 0.85 }} />
-                {s}
-              </button>
+                <button
+                  onClick={() => { setQuery(s); inputRef.current?.focus() }}
+                  className="flex items-center gap-1"
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'inherit', padding: 0 }}
+                >
+                  <Clock size={10} style={{ opacity: 0.85 }} />
+                  {s}
+                </button>
+                <button
+                  onClick={() => removeRecent(s)}
+                  aria-label={`Remove "${s}" from recent searches`}
+                  style={{ background: 'none', border: 'none', cursor: 'pointer', color: 'var(--slate)', opacity: 0.55, padding: 0, marginLeft: 2 }}
+                >
+                  <X size={10} />
+                </button>
+              </span>
             ))}
           </div>
         </div>
@@ -236,58 +728,51 @@ export default function SearchPage() {
           </div>
         )}
 
-        {!isLoading && debouncedQuery.length >= 2 && results.length === 0 && (
+        {/* S-16: distinguish error from empty results. */}
+        {!isLoading && isError && debouncedQuery.length >= 2 && (
           <EmptyState
-            icon={<Search size={40} />}
-            title="Nothing matched that"
-            subtitle="Try a different keyword, a person's name, or a project slug. The index covers tasks, projects, people, and decisions."
+            icon={<AlertTriangle size={40} />}
+            title="Couldn't reach search"
+            subtitle="Network or server error. Try again."
+            action={{ label: 'Retry', onClick: () => refetch() }}
           />
         )}
 
-        {!isLoading && results.length > 0 && (
+        {!isLoading && !isError && debouncedQuery.length >= 2 && results.length === 0 && (
+          <EmptyState
+            icon={<Search size={40} />}
+            title="Nothing matched that"
+            subtitle={
+              didYouMeanData?.token
+                ? `Try a different keyword. Did you mean "${didYouMeanData.token}"?`
+                : "Try a different keyword, a person's name, or a project slug."
+            }
+            action={
+              didYouMeanData?.token
+                ? { label: `Search "${didYouMeanData.token}" (${didYouMeanData.count})`, onClick: () => setQuery(didYouMeanData.token) }
+                : undefined
+            }
+          />
+        )}
+
+        {!isLoading && !isError && results.length > 0 && (
           <div className="flex flex-col gap-6">
-            <div className="flex items-center gap-2 flex-wrap sticky top-0 z-10 py-2" style={{ background: 'var(--page-bg)' }}>
-              <button
-                onClick={() => setTypeFilter([])}
-                className="rounded-full px-3 py-1 text-xs border transition-colors"
-                style={{
-                  borderColor: typeFilter.length === 0 ? 'var(--teal)' : 'var(--border-subtle)',
-                  color: typeFilter.length === 0 ? 'var(--teal)' : 'var(--slate)',
-                  background: typeFilter.length === 0 ? 'var(--teal-hover)' : 'transparent',
-                  cursor: 'pointer',
-                }}
-              >
-                All ({results.length})
-              </button>
-              {typeOrder.map((t) => {
-                const count = countByType[t] || 0
-                if (count === 0) return null
-                const active = typeFilter.includes(t)
-                const cfg = typeConfig[t] || typeConfig.activity
-                return (
-                  <button
-                    key={t}
-                    onClick={(e) => toggleType(t, e.shiftKey)}
-                    className="rounded-full px-3 py-1 text-xs border transition-colors"
-                    style={{
-                      borderColor: active ? cfg.color : 'var(--border-subtle)',
-                      color: active ? cfg.color : 'var(--slate)',
-                      background: active ? `${cfg.color}14` : 'transparent',
-                      cursor: 'pointer',
-                    }}
-                    title="Shift-click for multi-select"
-                  >
-                    {cfg.label}s ({count})
-                  </button>
-                )
-              })}
-            </div>
             <p className="text-xs" style={{ color: 'var(--slate)', opacity: 'var(--ink-label)' }}>
               {filteredResults.length} result{filteredResults.length !== 1 ? 's' : ''} for "{debouncedQuery}"
-              {typeFilter.length > 0 && ` (filtered)`}
+              {hasActiveFilters && ` (filtered)`}
             </p>
 
-            {typeOrder.map((type) => {
+            {/* MIXED + TIMELINE views: flat list ordered by score / time. */}
+            {(view === 'mixed' || view === 'timeline') && (
+              <motion.div className="flex flex-col gap-1" variants={staggerContainer} initial="hidden" animate="visible">
+                {orderedResults.map((item) => (
+                  <ResultRow key={`${item.type}:${item.id}`} item={item} tokens={tokens} />
+                ))}
+              </motion.div>
+            )}
+
+            {/* BY-TYPE view: grouped sections (legacy shape). */}
+            {view === 'by-type' && typeOrder.map((type) => {
               const items = grouped[type]
               if (!items?.length) return null
               const config = typeConfig[type] || typeConfig.activity
@@ -303,28 +788,7 @@ export default function SearchPage() {
                   </div>
                   <motion.div className="flex flex-col gap-1" variants={staggerContainer} initial="hidden" animate="visible">
                     {items.map((item) => (
-                      <motion.div key={item.id} variants={staggerItem}>
-                        <Link
-                          to={item.url || '#'}
-                          className="flex items-center gap-3 px-4 py-2.5 rounded-lg border transition-colors hover:shadow-sm"
-                          style={{ borderColor: 'var(--border-subtle)', textDecoration: 'none' }}
-                        >
-                          <div className="w-7 h-7 rounded flex items-center justify-center flex-shrink-0" style={{ backgroundColor: config.color + '14' }}>
-                            <Icon size={14} style={{ color: config.color }} />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <p className="text-sm truncate" style={{ color: 'var(--ink)' }}>
-                              {formatBrandName(item.title)}
-                            </p>
-                            {item.subtitle && (
-                              <p className="text-[10px] truncate mt-0.5" style={{ color: 'var(--slate)', opacity: 'var(--ink-label)' }}>
-                                {formatBrandName(item.subtitle)}
-                              </p>
-                            )}
-                          </div>
-                          <ArrowRight size={14} style={{ color: 'var(--slate)', opacity: 0.75, flexShrink: 0 }} />
-                        </Link>
-                      </motion.div>
+                      <ResultRow key={`${item.type}:${item.id}`} item={item} tokens={tokens} />
                     ))}
                   </motion.div>
                 </div>
@@ -332,9 +796,84 @@ export default function SearchPage() {
             })}
           </div>
         )}
-
-        {/* Empty state shown above when query returns no results */}
       </div>
+
+      {/* Suppress lint use of submittedQueries — kept for future analytics surfaces. */}
+      <span style={{ display: 'none' }}>{submittedQueries.size}</span>
     </div>
+  )
+}
+
+/** Single result row — handles snippet, highlights, type badge, timestamp. */
+function ResultRow({ item, tokens }: { item: SearchResult; tokens: string[] }) {
+  const config = typeConfig[item.type] || typeConfig.activity
+  const Icon = config.icon
+  const d = item.details || {}
+  // Hermes branding for AI-authored decisions/activity (Rule 29).
+  const isHermes = d.decided_by === 'claude-ai' || d.author_slug === 'claude-ai'
+
+  return (
+    <motion.div variants={staggerItem}>
+      <Link
+        to={item.url || '#'}
+        className="flex items-start gap-3 px-4 py-2.5 rounded-lg border transition-colors hover:shadow-sm"
+        style={{ borderColor: 'var(--border-subtle)', textDecoration: 'none' }}
+      >
+        <div
+          className="w-7 h-7 rounded flex items-center justify-center flex-shrink-0"
+          style={{ backgroundColor: config.color + '14' }}
+        >
+          {isHermes
+            ? <HermesMark variant="icon" size={14} color={config.color} />
+            : <Icon size={14} style={{ color: config.color }} />}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-start gap-2">
+            <p className="text-sm truncate flex-1" style={{ color: 'var(--ink)' }}>
+              <HighlightedText text={formatBrandName(item.title)} tokens={tokens} />
+            </p>
+            <TypeBadge result={item} />
+            {item.timestamp && (
+              <span
+                className="text-[10px] flex-shrink-0"
+                style={{ color: 'var(--slate)', opacity: 'var(--ink-label)', whiteSpace: 'nowrap' }}
+              >
+                {formatRelativeTime(item.timestamp)}
+              </span>
+            )}
+          </div>
+          {/* S-03: snippet (matched body text, with highlights). Falls back to subtitle when no snippet. */}
+          {item.snippet ? (
+            <p
+              className="text-[11px] mt-0.5"
+              style={{
+                color: 'var(--slate)',
+                opacity: 'var(--ink-label)',
+                lineHeight: 1.4,
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+                overflow: 'hidden',
+              }}
+            >
+              {item.matchedField && (
+                <span style={{ opacity: 0.7, marginRight: 4 }}>
+                  {item.matchedField}:
+                </span>
+              )}
+              <HighlightedText text={item.snippet} tokens={tokens} />
+            </p>
+          ) : item.subtitle ? (
+            <p
+              className="text-[10px] truncate mt-0.5"
+              style={{ color: 'var(--slate)', opacity: 'var(--ink-label)' }}
+            >
+              <HighlightedText text={formatBrandName(item.subtitle)} tokens={tokens} />
+            </p>
+          ) : null}
+        </div>
+        <ArrowRight size={14} style={{ color: 'var(--slate)', opacity: 0.75, flexShrink: 0, marginTop: 4 }} />
+      </Link>
+    </motion.div>
   )
 }


### PR DESCRIPTION
Wave 4 of audit/2026-04-28 fix phase. SearchPage rebuilt as a real investigation surface. Build clean, tsc clean.

## Closes (16/16)

### Foundation
- **S-01** Match highlighting via `<HighlightedText>` wrapper using `<mark>` w/ `--gold-emphasis`
- **S-02** View picker: Mixed | By type | Timeline. Persisted to `localStorage.search_view`. Mixed preserves backend score order; By type bucketed; Timeline by recency.
- **S-03** Backend snippets: extracts ~160-char excerpt centered on match + `matchedField`. Frontend renders 2-line snippet w/ token highlights.
- **S-04** Sticky input + chips (top: 0, z-sticky)
- **S-05** Recents save only on Enter — drops prefix-pollution
- **S-06** Misleading `@`/`#`/`/` tips removed

### Deeplinks + per-type rendering
- **S-07** Tasks SELECT now ships `project_id`; URL routes to `/portal/projects/${slug}?openTask=${id}` when present (project context preserved)
- **S-08** Files w/ `entity_type=meeting` route to `/portal/meetings/${id}` (was self-loop to /search)
- **S-09** `formatRelativeTime(item.timestamp)` right-aligned per row
- **S-12** Per-type `<TypeBadge>` for 6 highest-leverage types (task→Avatar, meeting→date pill, publication→journal+year, grant→FY+cost, decision→outcome, project→CategoryIcon)

### Filters + UX
- **S-10** Multi-select chips by default; Clear filter link
- **S-11** Person / Time / Status secondary filter row, all `aria-label`-d
- **S-13** Recents persist while typing, filtered by prefix; per-recent X button
- **S-14** LRU jump-to (reader wired; PortalLayout writer is small follow-up)
- **S-15** Token-retry 'Did you mean?' (multi-word queries; single-word Levenshtein deferred)
- **S-16** Error state distinguished — queryFn throws, error EmptyState w/ Retry action

## Deferrals (per bundle constraints)

- **S-12 row rendering**: 6/14 types shipped TypeBadge variants. Other 8 (idea/note/task_note/comment/task_comment/action_item/file/activity) keep current shape — kept inside 100-LOC type-specific limit.
- **S-14 LRU writer**: Reader wired (`getJumpToLRU()`); writer hook in PortalLayout to track route changes is a ~10-LOC follow-up.
- **S-15 fuzzy matching**: token-retry shipped (works on multi-word queries). Single-word typo correction (Levenshtein) deferred.

## Files

- `src/pages/portal/SearchPage.tsx` (+676 / -137)
- `api/routes/search.ts` (+153 / -5)
- `audit/2026-04-28/progress-log.md` (rebased away — entry will be re-added)

## Verification

- `npm run build` clean (TypeScript + Vite)
- `tsc --noEmit` clean
- All 16 findings verified STILL BROKEN against current source before fixing