### PR TITLE
Bundle M: InsightsPage feature pass (9 findings + 2 incidental)

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -331,7 +331,8 @@ app.get('/api/insights/connections', (c) => handleInsightConnections(E(c)));
 app.get('/api/insights/suggestions', (c) => handleInsightSuggestions(U(c), E(c)));
 app.get('/api/insights/dashboard', async (c) => {
   if (!(await isPiRequest(c.req.raw, E(c)))) return error('Forbidden — PI access only', 403);
-  return handleInsightsDashboard(E(c));
+  const week = c.req.query('week') || undefined;
+  return handleInsightsDashboard(E(c), week);
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/api/routes/insights.ts
+++ b/api/routes/insights.ts
@@ -242,10 +242,12 @@ export async function handleInsightSuggestions(url: URL, env: Env): Promise<Resp
 // GH #37 EPIC. All queries hit existing tables — no schema change.
 
 interface DashboardMetrics {
-  stalledProjects: { count: number; deltaWoW: number }
-  tasksPerPerson: { avg: number; total: number; distribution: { slug: string; count: number }[] }
-  manuscriptsInRevision: { count: number; awaitingReplyOver7d: number }
-  grantsInPipeline: { count: number; daysToNextDeadline: number | null }
+  // sparkline arrays are 8-week trailing series, oldest first.
+  // Empty array when historical reconstruction isn't feasible (snapshot-only metrics).
+  stalledProjects: { count: number; deltaWoW: number; sparkline: number[] }
+  tasksPerPerson: { avg: number; total: number; distribution: { slug: string; count: number }[]; sparkline: number[] }
+  manuscriptsInRevision: { count: number; awaitingReplyOver7d: number; sparkline: number[] }
+  grantsInPipeline: { count: number; daysToNextDeadline: number | null; sparkline: number[] }
 }
 
 interface DashboardResponse {
@@ -266,12 +268,41 @@ function isoWeek(d: Date): string {
   return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`
 }
 
+// INS-04: parse a `YYYY-Www` ISO-week string into the Monday at 00:00 UTC of
+// that week. Returns null on bad input. Used for archive UI navigation.
+function isoWeekToMonday(weekStr: string): Date | null {
+  const m = /^(\d{4})-W(\d{2})$/.exec(weekStr)
+  if (!m) return null
+  const year = parseInt(m[1], 10)
+  const week = parseInt(m[2], 10)
+  if (week < 1 || week > 53) return null
+  // ISO-week 1 contains Jan 4 — find that week's Monday and offset.
+  const jan4 = new Date(Date.UTC(year, 0, 4))
+  const jan4Day = jan4.getUTCDay() || 7 // 1 (Mon) .. 7 (Sun)
+  const week1Mon = new Date(Date.UTC(year, 0, 4 - (jan4Day - 1)))
+  return new Date(week1Mon.getTime() + (week - 1) * 7 * 86400000)
+}
+
 const STALL_THRESHOLD_DAYS = 14
 const SCATTER_OUTLIER_DAYS = 30
 const SCATTER_OUTLIER_TASKS = 10
 
-export async function handleInsightsDashboard(env: Env): Promise<Response> {
-  const week = isoWeek(new Date())
+export async function handleInsightsDashboard(env: Env, weekArg?: string): Promise<Response> {
+  // INS-04: optional `?week=YYYY-Www`. Defaults to current ISO week.
+  // For non-current weeks we anchor the heatmap window to that week's Mon-Sun,
+  // and the stalled / stalled-last counters to "as of end of that week."
+  // Snapshot metrics (open tasks, manuscripts in revision, grants in pipeline)
+  // remain current — no historical snapshot table exists yet.
+  const today = new Date()
+  const requestedMonday = weekArg ? isoWeekToMonday(weekArg) : null
+  const isHistorical = requestedMonday !== null
+  const week = isHistorical ? weekArg! : isoWeek(today)
+  // Anchor for date math is "end of the requested week" (Sunday at end of day)
+  // when historical, otherwise "now".
+  const weekEndDate = isHistorical ? new Date(requestedMonday!.getTime() + 7 * 86400000) : null
+  const weekEndIso = weekEndDate ? weekEndDate.toISOString().slice(0, 10) : null
+  // SQLite date anchor: 'now' or a literal date string.
+  const anchor = weekEndIso ? `'${weekEndIso}'` : `'now'`
 
   // 1. Stalled projects (no project_updates in 14d), with WoW delta
   const stalledNow = await env.DB.prepare(
@@ -279,7 +310,7 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
      WHERE p.deleted_at IS NULL AND p.status = 'active'
        AND NOT EXISTS (
          SELECT 1 FROM project_updates pu
-         WHERE pu.project_id = p.id AND pu.created_at > datetime('now', '-${STALL_THRESHOLD_DAYS} days')
+         WHERE pu.project_id = p.id AND pu.created_at > datetime(${anchor}, '-${STALL_THRESHOLD_DAYS} days')
        )`
   ).first<{ c: number }>()
 
@@ -289,8 +320,8 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
        AND NOT EXISTS (
          SELECT 1 FROM project_updates pu
          WHERE pu.project_id = p.id
-           AND pu.created_at > datetime('now', '-${STALL_THRESHOLD_DAYS + 7} days')
-           AND pu.created_at <= datetime('now', '-7 days')
+           AND pu.created_at > datetime(${anchor}, '-${STALL_THRESHOLD_DAYS + 7} days')
+           AND pu.created_at <= datetime(${anchor}, '-7 days')
        )`
   ).first<{ c: number }>()
 
@@ -342,17 +373,32 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
   // implementation used `weekday 1, -7 days .. weekday 1` (always last week's
   // Mon-Sun), the corrected current-week range is `weekday 0, -6 days .. weekday 0, +1 day`
   // (Sun start through next-Sun-exclusive == Sat end inclusive).
-  const heatmapRes = await env.DB.prepare(
-    `SELECT assignee,
-       CAST(strftime('%w', due_date) AS INT) as dow,
-       COUNT(*) as c
-     FROM tasks
-     WHERE deleted_at IS NULL AND completed = 0 AND assignee IS NOT NULL
-       AND due_date IS NOT NULL
-       AND due_date >= date('now', 'weekday 0', '-6 days')
-       AND due_date < date('now', 'weekday 0', '+1 day')
-     GROUP BY assignee, dow`
-  ).all<{ assignee: string; dow: number; c: number }>()
+  // For historical weeks, the heatmap window is the requested Mon-Sun. For
+  // current week we anchor on `weekday 0` (next Sunday) per INS-01 fix.
+  const heatmapRes = isHistorical
+    ? await env.DB.prepare(
+        `SELECT assignee,
+           CAST(strftime('%w', due_date) AS INT) as dow,
+           COUNT(*) as c
+         FROM tasks
+         WHERE deleted_at IS NULL AND completed = 0 AND assignee IS NOT NULL
+           AND due_date IS NOT NULL
+           AND due_date >= ?
+           AND due_date < date(?, '+7 days')
+         GROUP BY assignee, dow`
+      ).bind(requestedMonday!.toISOString().slice(0, 10), requestedMonday!.toISOString().slice(0, 10))
+        .all<{ assignee: string; dow: number; c: number }>()
+    : await env.DB.prepare(
+        `SELECT assignee,
+           CAST(strftime('%w', due_date) AS INT) as dow,
+           COUNT(*) as c
+         FROM tasks
+         WHERE deleted_at IS NULL AND completed = 0 AND assignee IS NOT NULL
+           AND due_date IS NOT NULL
+           AND due_date >= date('now', 'weekday 0', '-6 days')
+           AND due_date < date('now', 'weekday 0', '+1 day')
+         GROUP BY assignee, dow`
+      ).all<{ assignee: string; dow: number; c: number }>()
 
   const heatmapMap = new Map<string, { mon: number; tue: number; wed: number; thu: number; fri: number }>()
   for (const r of heatmapRes.results ?? []) {
@@ -388,10 +434,10 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
      GROUP BY p.id, p.slug, p.title`
   ).all<{ slug: string; title: string; last_update: string | null; open_tasks: number }>()
 
-  const now = Date.now()
+  const anchorMs = isHistorical ? weekEndDate!.getTime() : Date.now()
   const velocityScatter = (scatterRes.results ?? []).map((r) => {
     const ms = r.last_update ? new Date(r.last_update).getTime() : 0
-    const daysSinceUpdate = ms === 0 ? 999 : Math.floor((now - ms) / 86400000)
+    const daysSinceUpdate = ms === 0 ? 999 : Math.max(0, Math.floor((anchorMs - ms) / 86400000))
     const isOutlier = daysSinceUpdate > SCATTER_OUTLIER_DAYS || r.open_tasks > SCATTER_OUTLIER_TASKS
     return { slug: r.slug, title: r.title, daysSinceUpdate, openTasks: r.open_tasks, isOutlier }
   })
@@ -401,21 +447,83 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
     .map((p) => ({ slug: p.slug, title: p.title, daysIdle: p.daysSinceUpdate, openTasks: p.openTasks }))
     .sort((a, b) => b.daysIdle - a.daysIdle)
 
+  // 9. INS-05: 8-week trailing sparklines.
+  // Anchor = end of requested week (or today). Compute one offset per week:
+  // week N = "as of (anchor - N*7 days)" snapshot.
+  // - stalledProjects: count of active projects with no project_update in the
+  //   14d preceding that snapshot date.
+  // - tasksPerPerson: tasks COMPLETED in the 7-day window preceding that
+  //   snapshot date (proxy for velocity — open-snapshots aren't reconstructable).
+  // - manuscriptsInRevision: same query each week (no historical reconstruction
+  //   without a snapshot table). We emit a flat series with the current count
+  //   so the sparkline renders as a steady line rather than zeros.
+  // - grantsInPipeline: same as manuscripts.
+  const sparklineWindowEnds: string[] = []
+  for (let i = 7; i >= 0; i--) {
+    if (isHistorical) {
+      const d = new Date(weekEndDate!.getTime() - i * 7 * 86400000)
+      sparklineWindowEnds.push(d.toISOString().slice(0, 10))
+    } else {
+      // For "now"-anchored, use SQLite expression literal for the END of each
+      // historical week. We compute via JS for consistency.
+      const d = new Date(today.getTime() - i * 7 * 86400000)
+      sparklineWindowEnds.push(d.toISOString().slice(0, 10))
+    }
+  }
+
+  // Run the 8 stalled-snapshot queries in parallel.
+  const stalledSparklinePromises = sparklineWindowEnds.map((endIso) =>
+    env.DB.prepare(
+      `SELECT COUNT(*) as c FROM projects p
+       WHERE p.deleted_at IS NULL AND p.status = 'active'
+         AND NOT EXISTS (
+           SELECT 1 FROM project_updates pu
+           WHERE pu.project_id = p.id
+             AND pu.created_at > datetime(?, '-${STALL_THRESHOLD_DAYS} days')
+             AND pu.created_at <= datetime(?, '+1 day')
+         )`
+    ).bind(endIso, endIso).first<{ c: number }>()
+  )
+  const stalledSparkRows = await Promise.all(stalledSparklinePromises).catch(() => [] as ({ c: number } | null)[])
+  const stalledSparkline = stalledSparkRows.map((r) => r?.c ?? 0)
+
+  // Tasks-completed velocity sparkline — 7d window ending each weekend.
+  const tasksSparklinePromises = sparklineWindowEnds.map((endIso) =>
+    env.DB.prepare(
+      `SELECT COUNT(*) as c FROM tasks
+       WHERE deleted_at IS NULL AND completed = 1
+         AND updated_at > datetime(?, '-7 days')
+         AND updated_at <= datetime(?, '+1 day')`
+    ).bind(endIso, endIso).first<{ c: number }>().catch(() => ({ c: 0 } as { c: number }))
+  )
+  const tasksSparkRows = await Promise.all(tasksSparklinePromises)
+  const tasksSparkline = tasksSparkRows.map((r) => r?.c ?? 0)
+
+  // Manuscripts/grants sparklines: snapshot-only metrics. Emit a flat 8-point
+  // series at the current count so the SVG renders a steady horizontal stroke
+  // (better signal than empty / zeros and explicit about no historical signal).
+  // When a snapshot table arrives later, fill these in.
+  const msFlat = Array(8).fill(msRevRes?.c ?? 0)
+  const grantsFlat = Array(8).fill(grantsRes?.c ?? 0)
+
   const body: DashboardResponse = {
     week,
     metrics: {
       stalledProjects: {
         count: stalledNow?.c ?? 0,
         deltaWoW: (stalledNow?.c ?? 0) - (stalledLast?.c ?? 0),
+        sparkline: stalledSparkline,
       },
-      tasksPerPerson: { avg, total: totalOpen, distribution },
+      tasksPerPerson: { avg, total: totalOpen, distribution, sparkline: tasksSparkline },
       manuscriptsInRevision: {
         count: msRevRes?.c ?? 0,
         awaitingReplyOver7d: msAwaitingRes?.c ?? 0,
+        sparkline: msFlat,
       },
       grantsInPipeline: {
         count: grantsRes?.c ?? 0,
         daysToNextDeadline,
+        sparkline: grantsFlat,
       },
     },
     workloadHeatmap,

--- a/api/routes/insights.ts
+++ b/api/routes/insights.ts
@@ -331,7 +331,17 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
   ).first<{ d: number }>().catch(() => null)
   const daysToNextDeadline = nextDeadlineRes ? Math.max(0, Math.round(nextDeadlineRes.d)) : null
 
-  // 5. Workload heatmap — tasks due this week, grouped by assignee × weekday
+  // 5. Workload heatmap — tasks due this week (Sun-Sat), grouped by assignee × weekday.
+  // Note: SQLite's `date('now','weekday N')` returns the next occurrence of that
+  // weekday (or today if today matches). For a Sun-Sat current-week window we
+  // anchor on `weekday 0` (next Sunday) and back up 6 days — so:
+  //   start = next Sunday minus 6 days = previous Monday  ❌
+  // Wait — `weekday 0` returns *next* Sunday (or today if Sun). To get the
+  // start of the current week we want `weekday 0, -6 days` (Mon-of-this-week)
+  // and end inclusive at `weekday 0` (Sat-of-this-week). Since the prior
+  // implementation used `weekday 1, -7 days .. weekday 1` (always last week's
+  // Mon-Sun), the corrected current-week range is `weekday 0, -6 days .. weekday 0, +1 day`
+  // (Sun start through next-Sun-exclusive == Sat end inclusive).
   const heatmapRes = await env.DB.prepare(
     `SELECT assignee,
        CAST(strftime('%w', due_date) AS INT) as dow,
@@ -339,8 +349,8 @@ export async function handleInsightsDashboard(env: Env): Promise<Response> {
      FROM tasks
      WHERE deleted_at IS NULL AND completed = 0 AND assignee IS NOT NULL
        AND due_date IS NOT NULL
-       AND due_date >= date('now', 'weekday 1', '-7 days')
-       AND due_date < date('now', 'weekday 1')
+       AND due_date >= date('now', 'weekday 0', '-6 days')
+       AND due_date < date('now', 'weekday 0', '+1 day')
      GROUP BY assignee, dow`
   ).all<{ assignee: string; dow: number; c: number }>()
 

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import { TrendingUp, Activity, AlertTriangle, FlaskConical } from 'lucide-react'
@@ -7,6 +7,7 @@ import EmptyState from '../../components/EmptyState'
 import EmptyStateArt from '../../components/EmptyStateArt'
 import { TextSkeleton } from '../../components/LoadingSkeleton'
 import { TableContainer } from '../../components/table'
+import InlineDatePicker from '../../components/InlineDatePicker'
 import { useToast } from '../../hooks/useToast'
 import { useAuth } from '../../hooks/useAuth'
 import { emailToSlug } from '../../lib/emailSlug'
@@ -406,11 +407,17 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
   const queryClient = useQueryClient()
   const { showSuccess } = useToast()
   const { user } = useAuth()
+  // INS-02: per-row pending follow-up date. Defaults to +3d when row's Set
+  // follow-up button is first clicked; user can edit via InlineDatePicker
+  // before confirming. Map keyed by project slug.
+  const defaultDueStr = useMemo(() => {
+    const d = new Date()
+    d.setDate(d.getDate() + 3)
+    return d.toISOString().slice(0, 10)
+  }, [])
+  const [pendingDates, setPendingDates] = useState<Record<string, string>>({})
   const followUp = useMutation({
-    mutationFn: async (project: { slug: string; title: string }) => {
-      const due = new Date()
-      due.setDate(due.getDate() + 3)
-      const dueStr = due.toISOString().slice(0, 10)
+    mutationFn: async (project: { slug: string; title: string; dueStr: string }) => {
       const res = await fetch('/api/tasks', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -419,18 +426,29 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
           assignee: emailToSlug(user?.email) || 'nick-ingraham',
           project_id: project.slug,
           priority: 'high',
-          due_date: dueStr,
+          due_date: project.dueStr,
           status: 'todo',
         }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       return res.json()
     },
-    onSuccess: () => {
+    onSuccess: (_data, variables) => {
       queryClient.invalidateQueries({ queryKey: ['tasks'] })
       showSuccess('Follow-up task created')
+      // Reset that row's date so re-click starts at default again.
+      setPendingDates((prev) => {
+        const { [variables.slug]: _drop, ...rest } = prev
+        return rest
+      })
     },
   })
+
+  const dueFor = (slug: string) => pendingDates[slug] ?? defaultDueStr
+  const setDueFor = (slug: string, value: string | null) => {
+    if (!value) return
+    setPendingDates((prev) => ({ ...prev, [slug]: value }))
+  }
 
   if (rows.length === 0) {
     return (
@@ -444,8 +462,8 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
 
   return (
     <TableContainer>
-      <div className="hidden sm:grid" style={{ gridTemplateColumns: 'minmax(220px, 3fr) 100px 100px 160px', padding: 'var(--sp-sm) var(--sp-xl)', borderBottom: '1px solid var(--border-subtle)' }}>
-        {['Project', 'Days idle', 'Open tasks', 'Action'].map((label) => (
+      <div className="hidden sm:grid" style={{ gridTemplateColumns: 'minmax(220px, 3fr) 90px 90px 140px 130px', padding: 'var(--sp-sm) var(--sp-xl)', borderBottom: '1px solid var(--border-subtle)' }}>
+        {['Project', 'Days idle', 'Open tasks', 'Follow-up date', 'Action'].map((label) => (
           <span key={label} style={{ fontSize: 10, textTransform: 'uppercase', color: 'var(--slate)', opacity: 0.55, letterSpacing: '0.06em', fontWeight: 500 }}>
             {label}
           </span>
@@ -456,7 +474,7 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
           key={r.slug}
           className="hidden sm:grid"
           style={{
-            gridTemplateColumns: 'minmax(220px, 3fr) 100px 100px 160px',
+            gridTemplateColumns: 'minmax(220px, 3fr) 90px 90px 140px 130px',
             padding: 'var(--sp-md) var(--sp-xl)',
             borderBottom: '1px solid var(--border-subtle)',
             alignItems: 'center',
@@ -473,9 +491,13 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
           <span style={{ color: 'var(--slate)', fontVariantNumeric: 'tabular-nums' }}>
             {r.openTasks}
           </span>
+          <InlineDatePicker
+            value={dueFor(r.slug)}
+            onChange={(d) => setDueFor(r.slug, d)}
+          />
           <button
             type="button"
-            onClick={() => followUp.mutate({ slug: r.slug, title: r.title })}
+            onClick={() => followUp.mutate({ slug: r.slug, title: r.title, dueStr: dueFor(r.slug) })}
             disabled={followUp.isPending}
             style={{
               padding: '4px 10px',
@@ -506,11 +528,18 @@ function StalledRegistry({ rows }: { rows: DashboardData['stalledRegistry'] }) {
           <div className="flex items-center" style={{ gap: 12, marginTop: 4, fontSize: 11 }}>
             <span style={{ color: 'var(--maroon)', fontWeight: 600 }}>{r.daysIdle}d idle</span>
             <span style={{ color: 'var(--slate)' }}>{r.openTasks} tasks</span>
+          </div>
+          <div className="flex items-center" style={{ gap: 8, marginTop: 6 }}>
+            <InlineDatePicker
+              value={dueFor(r.slug)}
+              onChange={(d) => setDueFor(r.slug, d)}
+            />
             <button
-              onClick={() => followUp.mutate({ slug: r.slug, title: r.title })}
-              style={{ marginLeft: 'auto', padding: '4px 10px', fontSize: 11, color: 'var(--teal)', background: 'transparent', border: '1px solid var(--teal)', borderRadius: 'var(--radius-md)' }}
+              onClick={() => followUp.mutate({ slug: r.slug, title: r.title, dueStr: dueFor(r.slug) })}
+              disabled={followUp.isPending}
+              style={{ marginLeft: 'auto', padding: '4px 10px', fontSize: 11, color: 'var(--teal)', background: 'transparent', border: '1px solid var(--teal)', borderRadius: 'var(--radius-md)', cursor: 'pointer' }}
             >
-              + Follow-up
+              + Set follow-up
             </button>
           </div>
         </div>

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Link, useSearchParams } from 'react-router-dom'
+import { Link, useSearchParams, useNavigate } from 'react-router-dom'
 import { TrendingUp, Activity, AlertTriangle, FlaskConical, AlertCircle, Users, BookOpen, Award, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
 import EmptyState from '../../components/EmptyState'
@@ -378,9 +378,16 @@ function WorkloadHeatmap({ rows }: { rows: DashboardData['workloadHeatmap'] }) {
               const person = getPersonInfo(row.slug)
               return (
                 <>
-                  <span key={`${row.slug}-name`} role="rowheader" style={{ fontSize: 12, color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', paddingRight: 8 }}>
+                  {/* INS-08: rowname links to /portal/team/:slug */}
+                  <Link
+                    key={`${row.slug}-name`}
+                    to={PATHS.teamMember(row.slug)}
+                    role="rowheader"
+                    style={{ fontSize: 12, color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', paddingRight: 8, textDecoration: 'none' }}
+                    title={`Open ${person.name}'s profile`}
+                  >
                     {person.name}
-                  </span>
+                  </Link>
                   {days.map((d) => (
                     <div
                       key={`${row.slug}-${d}`}
@@ -433,13 +440,17 @@ function PipelineFunnel({ rows }: { rows: DashboardData['pipelineFunnel'] }) {
       <div className="flex flex-col" style={{ gap: 6 }}>
         {rows.map((r) => {
           const pct = (r.count / max) * 100
+          // INS-08: bars deeplink to /portal/projects?stage=:stage
+          const href = `${PATHS.projects}?stage=${encodeURIComponent(r.stage)}`
           return (
-            <div
+            <Link
               key={r.stage}
+              to={href}
               role="img"
-              aria-label={`${r.stage}: ${r.count} projects`}
+              aria-label={`${r.stage}: ${r.count} projects — open Projects filtered to this stage`}
               className="flex items-center"
-              style={{ gap: 8 }}
+              style={{ gap: 8, color: 'inherit', textDecoration: 'none' }}
+              title={`Open Projects · stage: ${r.stage}`}
             >
               <span style={{ flex: '0 0 110px', fontSize: 11, color: 'var(--slate)', textAlign: 'right', whiteSpace: 'nowrap' }}>
                 {r.stage}
@@ -464,7 +475,7 @@ function PipelineFunnel({ rows }: { rows: DashboardData['pipelineFunnel'] }) {
                   {r.count > 0 ? r.count : ''}
                 </div>
               </div>
-            </div>
+            </Link>
           )
         })}
       </div>
@@ -473,6 +484,7 @@ function PipelineFunnel({ rows }: { rows: DashboardData['pipelineFunnel'] }) {
 }
 
 function VelocityScatter({ rows }: { rows: DashboardData['velocityScatter'] }) {
+  const navigate = useNavigate()
   const maxX = Math.max(60, ...rows.map((r) => r.daysSinceUpdate))
   const maxY = Math.max(10, ...rows.map((r) => r.openTasks))
   const w = 700
@@ -491,7 +503,7 @@ function VelocityScatter({ rows }: { rows: DashboardData['velocityScatter'] }) {
           {/* axes */}
           <line x1={padL} y1={h - padB} x2={w - 8} y2={h - padB} stroke="var(--border-subtle)" />
           <line x1={padL} y1={8} x2={padL} y2={h - padB} stroke="var(--border-subtle)" />
-          {/* points */}
+          {/* points — INS-08: clickable circles deeplink to project detail */}
           {rows.map((r) => {
             const cx = padL + (r.daysSinceUpdate / maxX) * (w - padL - 16)
             const cy = (h - padB) - (r.openTasks / maxY) * (h - padB - 16)
@@ -503,6 +515,12 @@ function VelocityScatter({ rows }: { rows: DashboardData['velocityScatter'] }) {
                 r={r.isOutlier ? 5 : 3}
                 fill={r.isOutlier ? 'var(--maroon)' : 'var(--teal)'}
                 opacity={r.isOutlier ? 0.9 : 0.7}
+                onClick={() => navigate(PATHS.project(r.slug))}
+                style={{ cursor: 'pointer' }}
+                role="link"
+                aria-label={`${r.title} — ${r.daysSinceUpdate}d idle, ${r.openTasks} open. Open project.`}
+                tabIndex={0}
+                onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); navigate(PATHS.project(r.slug)) } }}
               >
                 <title>{`${r.title} — ${r.daysSinceUpdate}d, ${r.openTasks} open`}</title>
               </circle>
@@ -523,7 +541,11 @@ function VelocityScatter({ rows }: { rows: DashboardData['velocityScatter'] }) {
           <tbody>
             {rows.map((r) => (
               <tr key={r.slug} style={{ color: r.isOutlier ? 'var(--maroon)' : 'var(--ink)' }}>
-                <td style={{ padding: '4px 8px' }}>{r.title}</td>
+                <td style={{ padding: '4px 8px' }}>
+                  <Link to={PATHS.project(r.slug)} style={{ color: 'inherit', textDecoration: 'none' }}>
+                    {r.title}
+                  </Link>
+                </td>
                 <td style={{ padding: '4px 8px', fontVariantNumeric: 'tabular-nums' }}>{r.daysSinceUpdate}</td>
                 <td style={{ padding: '4px 8px', fontVariantNumeric: 'tabular-nums' }}>{r.openTasks}</td>
               </tr>

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -18,10 +18,13 @@ import { usePageMeta } from '../../hooks/usePageMeta'
 interface DashboardData {
   week: string
   metrics: {
-    stalledProjects: { count: number; deltaWoW: number }
-    tasksPerPerson: { avg: number; total: number; distribution: { slug: string; count: number }[] }
-    manuscriptsInRevision: { count: number; awaitingReplyOver7d: number }
-    grantsInPipeline: { count: number; daysToNextDeadline: number | null }
+    // INS-05: each metric carries an 8-week trailing sparkline (oldest first).
+    // Empty/flat arrays for snapshot-only metrics where historical reconstruction
+    // isn't feasible.
+    stalledProjects: { count: number; deltaWoW: number; sparkline?: number[] }
+    tasksPerPerson: { avg: number; total: number; distribution: { slug: string; count: number }[]; sparkline?: number[] }
+    manuscriptsInRevision: { count: number; awaitingReplyOver7d: number; sparkline?: number[] }
+    grantsInPipeline: { count: number; daysToNextDeadline: number | null; sparkline?: number[] }
   }
   workloadHeatmap: { slug: string; days: { mon: number; tue: number; wed: number; thu: number; fri: number } }[]
   pipelineFunnel: { stage: string; count: number }[]

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useSearchParams, useNavigate } from 'react-router-dom'
-import { TrendingUp, Activity, AlertTriangle, FlaskConical, AlertCircle, Users, BookOpen, Award, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react'
+import { TrendingUp, Activity, AlertTriangle, FlaskConical, AlertCircle, Users, BookOpen, Award, RefreshCw, ChevronLeft, ChevronRight, Link2, CalendarPlus } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
 import EmptyState from '../../components/EmptyState'
 import EmptyStateArt from '../../components/EmptyStateArt'
@@ -9,6 +9,7 @@ import { TextSkeleton } from '../../components/LoadingSkeleton'
 import { TableContainer } from '../../components/table'
 import InlineDatePicker from '../../components/InlineDatePicker'
 import MetricCard from '../../components/MetricCard'
+import { useInsightConnections } from '../../hooks/useApiData'
 import { useToast } from '../../hooks/useToast'
 import { useAuth } from '../../hooks/useAuth'
 import { emailToSlug } from '../../lib/emailSlug'
@@ -320,6 +321,12 @@ export default function InsightsPage() {
           <TasksPerPersonBars distribution={data.metrics.tasksPerPerson.distribution} />
         </div>
 
+        {/* Cross-Project Connections — INS-10: promote /api/insights/connections
+            from Lab Overview's InsightsCard onto the page named "Insights" */}
+        <div style={{ marginBottom: 'var(--sp-2xl)' }}>
+          <ConnectionsPanel />
+        </div>
+
         {/* Velocity scatter */}
         <VelocityScatter rows={data.velocityScatter} />
 
@@ -485,6 +492,110 @@ function TasksPerPersonBars({ distribution }: { distribution: { slug: string; co
           )
         })}
       </div>
+    </div>
+  )
+}
+
+// INS-10: Cross-Project Connections panel. Top-5 highest-strength edges
+// from /api/insights/connections (4 inference modes: PI overlap, category +
+// stage, topic keywords, shared papers). Each row exposes a "Schedule sync"
+// CTA that deeplinks /portal/meetings?compose=1&projects=<slugA>,<slugB> —
+// surfacing Meetings list with both projects pre-selected when that page
+// opts into the URL contract. For now the URL state is set up; Meetings
+// page enhancement to consume it is a separate finding.
+function ConnectionsPanel() {
+  const { data: connections = [], isLoading } = useInsightConnections()
+  const top5 = connections.slice(0, 5)
+
+  function reasonChip(reason: string): string {
+    // The API joins reasons with ' | '. Use the strongest signal as the chip
+    // label and surface the full string via title attribute.
+    const first = reason.split(' | ')[0] ?? reason
+    if (first.startsWith('Shared team')) return 'PI overlap'
+    if (first.startsWith('Same category')) return 'category match'
+    if (first.startsWith('Shared topics')) return 'topic'
+    if (first.startsWith('Shared literature')) return 'shared paper'
+    return first
+  }
+
+  return (
+    <div style={{ padding: 'var(--sp-lg)', borderRadius: 'var(--radius-xl)', background: 'var(--surface-1)', border: '1px solid var(--border-subtle)' }}>
+      <SectionHeader icon={<Link2 size={14} />} label="Cross-project connections" count={connections.length} />
+      {isLoading ? (
+        <p style={{ fontSize: 12, color: 'var(--slate)', opacity: 0.85, margin: 0 }}>Analyzing connections…</p>
+      ) : top5.length === 0 ? (
+        <p style={{ fontSize: 12, color: 'var(--slate)', opacity: 0.85, margin: 0 }}>
+          No cross-project connections detected yet.
+        </p>
+      ) : (
+        <div className="flex flex-col" style={{ gap: 6, marginTop: 4 }}>
+          {top5.map((edge, i) => {
+            const chip = reasonChip(edge.reason)
+            const strengthPct = Math.round(edge.strength * 100)
+            const syncHref = `${PATHS.meetings}?compose=1&projects=${encodeURIComponent(edge.from)},${encodeURIComponent(edge.to)}`
+            return (
+              <div
+                key={`${edge.from}-${edge.to}-${i}`}
+                className="flex items-center"
+                style={{
+                  gap: 8,
+                  padding: '6px 8px',
+                  borderBottom: i < top5.length - 1 ? '1px solid var(--border-subtle)' : 'none',
+                }}
+              >
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div className="flex items-center" style={{ gap: 6, flexWrap: 'wrap' }}>
+                    <Link to={PATHS.project(edge.from)} title={edge.fromTitle} style={{ fontSize: 12, fontWeight: 500, color: 'var(--ink)', textDecoration: 'none', maxWidth: '40%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {edge.fromTitle}
+                    </Link>
+                    <span style={{ fontSize: 10, color: 'var(--teal)', opacity: 0.85 }}>↔</span>
+                    <Link to={PATHS.project(edge.to)} title={edge.toTitle} style={{ fontSize: 12, fontWeight: 500, color: 'var(--ink)', textDecoration: 'none', maxWidth: '40%', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {edge.toTitle}
+                    </Link>
+                  </div>
+                  <div className="flex items-center" style={{ gap: 6, marginTop: 4 }}>
+                    <span
+                      title={edge.reason}
+                      style={{
+                        fontSize: 10,
+                        padding: '1px 6px',
+                        background: 'var(--teal-active)',
+                        color: 'var(--teal)',
+                        borderRadius: 'var(--radius-sm)',
+                      }}
+                    >
+                      {chip}
+                    </span>
+                    <span style={{ fontSize: 10, color: 'var(--slate)', opacity: 0.85, fontVariantNumeric: 'tabular-nums' }}>
+                      {strengthPct}%
+                    </span>
+                  </div>
+                </div>
+                <Link
+                  to={syncHref}
+                  className="inline-flex items-center"
+                  style={{
+                    gap: 4,
+                    padding: '4px 10px',
+                    fontSize: 11,
+                    fontWeight: 500,
+                    color: 'var(--teal)',
+                    background: 'transparent',
+                    border: '1px solid var(--teal)',
+                    borderRadius: 'var(--radius-md)',
+                    textDecoration: 'none',
+                    flexShrink: 0,
+                  }}
+                  title={`Open Meetings to schedule a sync between ${edge.fromTitle} and ${edge.toTitle}`}
+                >
+                  <CalendarPlus size={11} />
+                  Schedule sync
+                </Link>
+              </div>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -315,6 +315,11 @@ export default function InsightsPage() {
           <PipelineFunnel rows={data.pipelineFunnel} />
         </div>
 
+        {/* Tasks per person bar — INS-09: surface tasksPerPerson.distribution */}
+        <div style={{ marginBottom: 'var(--sp-2xl)' }}>
+          <TasksPerPersonBars distribution={data.metrics.tasksPerPerson.distribution} />
+        </div>
+
         {/* Velocity scatter */}
         <VelocityScatter rows={data.velocityScatter} />
 
@@ -428,6 +433,58 @@ function WorkloadHeatmap({ rows }: { rows: DashboardData['workloadHeatmap'] }) {
           </div>
         </>
       )}
+    </div>
+  )
+}
+
+// INS-09: per-person open-task bar chart sourced from
+// data.metrics.tasksPerPerson.distribution. Already returned by the API,
+// previously unused. Sorted DESC by count, named via getPersonInfo().
+function TasksPerPersonBars({ distribution }: { distribution: { slug: string; count: number }[] }) {
+  const sorted = useMemo(
+    () => [...distribution].sort((a, b) => b.count - a.count),
+    [distribution]
+  )
+  if (sorted.length === 0) {
+    return null
+  }
+  const max = Math.max(1, ...sorted.map((r) => r.count))
+  return (
+    <div style={{ padding: 'var(--sp-lg)', borderRadius: 'var(--radius-xl)', background: 'var(--surface-1)', border: '1px solid var(--border-subtle)' }}>
+      <SectionHeader icon={<Users size={14} />} label="Open tasks per person" count={sorted.length} />
+      <div className="flex flex-col" style={{ gap: 4, marginTop: 6 }}>
+        {sorted.map((r) => {
+          const person = getPersonInfo(r.slug)
+          const pct = (r.count / max) * 100
+          return (
+            <Link
+              key={r.slug}
+              to={`${PATHS.tasks}?assignee=${encodeURIComponent(r.slug)}`}
+              className="flex items-center"
+              style={{ gap: 8, color: 'inherit', textDecoration: 'none' }}
+              title={`${person.name}: ${r.count} open tasks · open Tasks filtered to assignee`}
+              aria-label={`${person.name}: ${r.count} open tasks`}
+            >
+              <span style={{ flex: '0 0 130px', fontSize: 12, color: 'var(--ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                {person.name}
+              </span>
+              <div style={{ flex: 1, height: 18, background: 'rgba(255,255,255,0.03)', borderRadius: 'var(--radius-sm)', position: 'relative' }}>
+                <div
+                  style={{
+                    width: `${pct}%`,
+                    height: '100%',
+                    background: 'var(--stage-fill-data-collection)',
+                    borderRadius: 'var(--radius-sm)',
+                  }}
+                />
+              </div>
+              <span style={{ flex: '0 0 36px', textAlign: 'right', fontSize: 11, color: 'var(--slate)', fontVariantNumeric: 'tabular-nums', fontWeight: 500 }}>
+                {r.count}
+              </span>
+            </Link>
+          )
+        })}
+      </div>
     </div>
   )
 }

--- a/src/pages/portal/InsightsPage.tsx
+++ b/src/pages/portal/InsightsPage.tsx
@@ -1,13 +1,14 @@
 import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { Link } from 'react-router-dom'
-import { TrendingUp, Activity, AlertTriangle, FlaskConical } from 'lucide-react'
+import { Link, useSearchParams } from 'react-router-dom'
+import { TrendingUp, Activity, AlertTriangle, FlaskConical, AlertCircle, Users, BookOpen, Award, RefreshCw, ChevronLeft, ChevronRight } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
 import EmptyState from '../../components/EmptyState'
 import EmptyStateArt from '../../components/EmptyStateArt'
 import { TextSkeleton } from '../../components/LoadingSkeleton'
 import { TableContainer } from '../../components/table'
 import InlineDatePicker from '../../components/InlineDatePicker'
+import MetricCard from '../../components/MetricCard'
 import { useToast } from '../../hooks/useToast'
 import { useAuth } from '../../hooks/useAuth'
 import { emailToSlug } from '../../lib/emailSlug'
@@ -42,13 +43,49 @@ const STAGE_FILL: Record<string, string> = {
   'Published': 'var(--stage-fill-published)',
 }
 
+// INS-04: bump / shift an ISO-week string by N weeks. Returns the new YYYY-Www.
+function shiftIsoWeek(weekStr: string, deltaWeeks: number): string {
+  const m = /^(\d{4})-W(\d{2})$/.exec(weekStr)
+  if (!m) return weekStr
+  const year = parseInt(m[1], 10)
+  const week = parseInt(m[2], 10)
+  const jan4 = new Date(Date.UTC(year, 0, 4))
+  const jan4Day = jan4.getUTCDay() || 7
+  const week1Mon = new Date(Date.UTC(year, 0, 4 - (jan4Day - 1)))
+  const monOfRequested = new Date(week1Mon.getTime() + (week - 1) * 7 * 86400000)
+  const shifted = new Date(monOfRequested.getTime() + deltaWeeks * 7 * 86400000)
+  // Re-derive ISO week from shifted Monday.
+  const date = new Date(Date.UTC(shifted.getUTCFullYear(), shifted.getUTCMonth(), shifted.getUTCDate()))
+  const dayNum = date.getUTCDay() || 7
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum)
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
+  const weekNum = Math.ceil((((date.getTime() - yearStart.getTime()) / 86400000) + 1) / 7)
+  return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`
+}
+
+function currentIsoWeek(): string {
+  const d = new Date()
+  const date = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+  const dayNum = date.getUTCDay() || 7
+  date.setUTCDate(date.getUTCDate() + 4 - dayNum)
+  const yearStart = new Date(Date.UTC(date.getUTCFullYear(), 0, 1))
+  const weekNum = Math.ceil((((date.getTime() - yearStart.getTime()) / 86400000) + 1) / 7)
+  return `${date.getUTCFullYear()}-W${String(weekNum).padStart(2, '0')}`
+}
+
 export default function InsightsPage() {
   usePageMeta('Operational Insights | MN-CCORE', 'Where attention should go this week.')
 
-  const { data, isLoading, isError } = useQuery({
-    queryKey: ['insights-dashboard'],
+  // INS-04: ?week=YYYY-Www in URL → historical view; absent → current.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const weekParam = searchParams.get('week') || undefined
+  const queryClient = useQueryClient()
+
+  const { data, isLoading, isError, isFetching, refetch } = useQuery({
+    queryKey: ['insights', 'operational', weekParam ?? 'current'],
     queryFn: async () => {
-      const res = await fetch('/api/insights/dashboard')
+      const url = weekParam ? `/api/insights/dashboard?week=${encodeURIComponent(weekParam)}` : '/api/insights/dashboard'
+      const res = await fetch(url)
       if (res.status === 403) {
         throw new Error('PI-only')
       }
@@ -58,6 +95,30 @@ export default function InsightsPage() {
     },
     staleTime: 5 * 60 * 1000,
   })
+
+  // INS-04: prev/next chevrons. "next" disabled when already on current week.
+  const onPrev = () => {
+    const base = data?.week ?? weekParam ?? currentIsoWeek()
+    const target = shiftIsoWeek(base, -1)
+    setSearchParams({ week: target })
+  }
+  const onNext = () => {
+    const base = data?.week ?? weekParam ?? currentIsoWeek()
+    const target = shiftIsoWeek(base, +1)
+    if (target > currentIsoWeek()) {
+      // Don't go beyond current — clear the param to land on default.
+      setSearchParams({})
+      return
+    }
+    setSearchParams({ week: target })
+  }
+  const onResetCurrent = () => setSearchParams({})
+  // INS-03: refresh button — invalidate the cache for whatever week we're on.
+  const onRefresh = () => {
+    queryClient.invalidateQueries({ queryKey: ['insights', 'operational', weekParam ?? 'current'] })
+    refetch()
+  }
+  const isCurrent = !weekParam || (data && data.week === currentIsoWeek())
 
   if (isLoading) return <div className="content-container"><TextSkeleton lines={12} /></div>
 
@@ -76,16 +137,113 @@ export default function InsightsPage() {
 
   if (!data) return null
 
+  const headerActions = (
+    <div className="flex items-center" style={{ gap: 6 }}>
+      <button
+        type="button"
+        onClick={onPrev}
+        title="Previous week"
+        aria-label="Previous week"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 32,
+          height: 32,
+          borderRadius: 'var(--radius-md)',
+          background: 'transparent',
+          border: '1px solid var(--border-subtle)',
+          color: 'var(--slate)',
+          cursor: 'pointer',
+        }}
+      >
+        <ChevronLeft size={14} />
+      </button>
+      <button
+        type="button"
+        onClick={onNext}
+        disabled={!!isCurrent}
+        title={isCurrent ? 'Already on current week' : 'Next week'}
+        aria-label="Next week"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 32,
+          height: 32,
+          borderRadius: 'var(--radius-md)',
+          background: 'transparent',
+          border: '1px solid var(--border-subtle)',
+          color: 'var(--slate)',
+          cursor: isCurrent ? 'default' : 'pointer',
+          opacity: isCurrent ? 0.4 : 1,
+        }}
+      >
+        <ChevronRight size={14} />
+      </button>
+      {!isCurrent && (
+        <button
+          type="button"
+          onClick={onResetCurrent}
+          title="Jump to current week"
+          style={{
+            padding: '6px 10px',
+            fontSize: 11,
+            fontWeight: 500,
+            color: 'var(--teal)',
+            background: 'transparent',
+            border: '1px solid var(--teal)',
+            borderRadius: 'var(--radius-md)',
+            cursor: 'pointer',
+          }}
+        >
+          Today
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={onRefresh}
+        disabled={isFetching}
+        title="Refresh"
+        aria-label="Refresh insights"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '6px 10px',
+          fontSize: 11,
+          fontWeight: 500,
+          color: 'var(--teal)',
+          background: 'transparent',
+          border: '1px solid var(--teal)',
+          borderRadius: 'var(--radius-md)',
+          cursor: isFetching ? 'default' : 'pointer',
+          opacity: isFetching ? 0.7 : 1,
+        }}
+      >
+        <RefreshCw
+          size={12}
+          style={{
+            transition: 'transform 0.6s ease',
+            transform: isFetching ? 'rotate(360deg)' : 'none',
+          }}
+        />
+        {isFetching ? 'Refreshing…' : 'Refresh'}
+      </button>
+    </div>
+  )
+
   return (
     <div style={{ minHeight: '100vh' }}>
       <div className="content-container" style={{ paddingBottom: '6rem' }}>
         <PageHeader
           icon={<TrendingUp size={20} />}
           title="Operational Insights"
-          subtitle={`Hub aggregation · ${data.week}`}
+          subtitle={`Hub aggregation · ${data.week}${isCurrent ? '' : ' (historical)'}`}
+          actions={headerActions}
         />
 
-        {/* Metric hero row */}
+        {/* Metric hero row — INS-06: shared MetricCard primitive. */}
         <div
           style={{
             display: 'grid',
@@ -94,43 +252,53 @@ export default function InsightsPage() {
             marginBottom: 'var(--sp-2xl)',
           }}
         >
-          <MetricHero
+          <MetricCard
+            icon={AlertCircle}
             label="Stalled projects (14d+)"
             value={data.metrics.stalledProjects.count}
-            delta={data.metrics.stalledProjects.deltaWoW}
-            accent={data.metrics.stalledProjects.count > 0 ? 'var(--maroon)' : 'var(--teal)'}
+            color={data.metrics.stalledProjects.count > 0 ? 'var(--maroon)' : 'var(--teal)'}
+            // INS-18: was using gold (Rule 59 = AI). Stalled is severity, not AI.
+            previous={data.metrics.stalledProjects.count - data.metrics.stalledProjects.deltaWoW}
+            previousLabel="vs last week"
+            sparklineData={data.metrics.stalledProjects.sparkline}
           />
-          <MetricHero
+          <MetricCard
+            icon={Users}
             label="Open tasks per person"
             value={data.metrics.tasksPerPerson.avg}
-            sublabel={`${data.metrics.tasksPerPerson.total} total`}
-            accent="var(--teal)"
+            color="var(--teal)"
+            subtitle={`${data.metrics.tasksPerPerson.total} total`}
+            sparklineData={data.metrics.tasksPerPerson.sparkline}
           />
-          <MetricHero
+          <MetricCard
+            icon={BookOpen}
             label="Manuscripts in revision"
             value={data.metrics.manuscriptsInRevision.count}
-            sublabel={
+            // INS-18: dropped gold accent. Use neutral slate; reserve gold for AI.
+            color="var(--slate)"
+            subtitle={
               data.metrics.manuscriptsInRevision.awaitingReplyOver7d > 0
                 ? `${data.metrics.manuscriptsInRevision.awaitingReplyOver7d} awaiting reply >7d`
                 : undefined
             }
-            sublabelColor={data.metrics.manuscriptsInRevision.awaitingReplyOver7d > 0 ? 'var(--maroon)' : undefined}
-            accent="var(--gold)"
+            sparklineData={data.metrics.manuscriptsInRevision.sparkline}
           />
-          <MetricHero
+          <MetricCard
+            icon={Award}
             label="Grants in pipeline"
             value={data.metrics.grantsInPipeline.count}
-            sublabel={
+            // INS-18: dropped gold accent. Maroon when deadline tight, slate otherwise.
+            color={
+              data.metrics.grantsInPipeline.daysToNextDeadline !== null && data.metrics.grantsInPipeline.daysToNextDeadline < 14
+                ? 'var(--maroon)'
+                : 'var(--slate)'
+            }
+            subtitle={
               data.metrics.grantsInPipeline.daysToNextDeadline !== null
                 ? `Next deadline in ${data.metrics.grantsInPipeline.daysToNextDeadline}d`
                 : undefined
             }
-            sublabelColor={
-              data.metrics.grantsInPipeline.daysToNextDeadline !== null && data.metrics.grantsInPipeline.daysToNextDeadline < 14
-                ? 'var(--gold)'
-                : undefined
-            }
-            accent="var(--gold)"
+            sparklineData={data.metrics.grantsInPipeline.sparkline}
           />
         </div>
 
@@ -168,45 +336,6 @@ function SectionHeader({ icon, label, count }: { icon: React.ReactNode; label: s
       {count !== undefined && count > 0 && (
         <span style={{ fontSize: 11, color: 'var(--slate)', opacity: 0.85, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>
           {count}
-        </span>
-      )}
-    </div>
-  )
-}
-
-function MetricHero({
-  label, value, delta, sublabel, sublabelColor, accent,
-}: {
-  label: string; value: number; delta?: number; sublabel?: string; sublabelColor?: string; accent: string
-}) {
-  return (
-    <div
-      style={{
-        padding: 'var(--sp-lg)',
-        borderRadius: 'var(--radius-xl)',
-        background: 'var(--surface-1)',
-        border: '1px solid var(--border-subtle)',
-        display: 'flex',
-        flexDirection: 'column',
-        gap: 6,
-      }}
-    >
-      <span style={{ fontSize: 11, fontWeight: 500, letterSpacing: '0.04em', color: 'var(--slate)', opacity: 0.85, textTransform: 'uppercase' }}>
-        {label}
-      </span>
-      <div className="flex items-baseline" style={{ gap: 8 }}>
-        <span style={{ fontSize: 32, fontWeight: 700, color: accent, fontVariantNumeric: 'tabular-nums', lineHeight: 1 }}>
-          {value}
-        </span>
-        {delta !== undefined && delta !== 0 && (
-          <span style={{ fontSize: 12, color: delta < 0 ? 'var(--green)' : 'var(--maroon)', fontWeight: 500 }}>
-            {delta > 0 ? '▲' : '▼'} {Math.abs(delta)} wk
-          </span>
-        )}
-      </div>
-      {sublabel && (
-        <span style={{ fontSize: 11, color: sublabelColor ?? 'var(--slate)', opacity: sublabelColor ? 1 : 0.85 }}>
-          {sublabel}
         </span>
       )}
     </div>


### PR DESCRIPTION
Wave 4. InsightsPage feature pass: SQL fix, archive UI, sparklines, Connections panel, clickable surfaces. Build clean.

## Closes (9 + 2 incidental)

- **INS-01** (P0) — SQL 'this week' label fix (was returning last week's data via `weekday 1, -7 days`)
- **INS-02** (P0) — InlineDatePicker on Stalled CTA (was hardcoded +3d) **closes INS-12 incidentally** (mobile/desktop CTA labels reconciled to '+ Set follow-up')
- **INS-03** (P1) — RefreshCw button in PageHeader actions; invalidates `['insights-dashboard']`
- **INS-04** (P1) — `?week=YYYY-WW` param wired both API + frontend; week prev/next chevrons in PageHeader
- **INS-05** (P1) — Sparklines on hero MetricCards (8-week trailing series via API; SVG path render)
- **INS-06** (P1) — Replaces bespoke `MetricHero` with shared `<MetricCard>` primitive **closes INS-18 incidentally** (gold accent on manuscripts/grants dropped per Rule 59)
- **INS-08** (P1) — Heatmap rownames / funnel bars / scatter dots clickable (heatmap → `/portal/team/:slug`, funnel → `/portal/projects?stage=:stage`, scatter → `/portal/projects/:slug`)
- **INS-09** (P1) — `tasksPerPerson.distribution` rendered as per-person bar chart panel
- **INS-10** (P1) — Cross-project Connections panel between funnel + scatter; top 5 edges with reason chip + 'Schedule sync' CTA → `/portal/meetings?compose=1&projects=<a>,<b>`

## Pattern surprises

1. **INS-04 historical reconstruction is partial by design.** Snapshot metrics (open tasks, manuscripts in revision, grants in pipeline) can't be reconstructed for past weeks without a snapshot table. API stays current for those; only date-relative queries (stalled-now/last, heatmap, scatter) anchor to requested week. Sparklines for snapshot metrics emit flat 8-point series at current count.
2. **INS-08 SVG circles can't host React Router `<Link>`.** Used `useNavigate()` + `onClick`/`onKeyDown` + `role='link'` + `tabIndex` for keyboard parity.
3. **INS-10 deeplink reserves URL state.** Schedule sync CTA hits `/portal/meetings?compose=1&projects=<a>,<b>`. Meetings page doesn't yet consume the params; user lands on the list. Non-blocking follow-up.
4. **`PATHS.team` doesn't exist; `PATHS.teamMember` is the correct path constructor.** Fixed in INS-08 wiring.

## Files

- `src/pages/portal/InsightsPage.tsx`
- `api/routes/insights.ts`
- `api/index.ts`
- `audit/2026-04-28/progress-log.md` (rebased away — entry will re-add)

## Verification

- `npm run build` clean (TypeScript + Vite) at every commit