### PR TITLE
Bundle R: TodayPage Tier-1 (9 findings)

### DIFF
--- a/src/components/today/MeetingRow.tsx
+++ b/src/components/today/MeetingRow.tsx
@@ -20,6 +20,21 @@ export function EventRow({ e, onDismiss, overlap = false, note, onNote }: { e: T
         </span>
         <span style={{ width: 6, height: 6, borderRadius: '50%', background: ACCENT_TEAL, flexShrink: 0 }} />
         <span style={{ flex: 1, fontSize: 13, color: INK, minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{e.title}</span>
+        {e.meetingUrl && (
+          <a
+            href={e.meetingUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(ev) => ev.stopPropagation()}
+            title="Open meeting link in a new tab"
+            style={{ display: 'inline-flex', alignItems: 'center', gap: 4, padding: '2px 8px', fontSize: 11, fontWeight: 600, color: ACCENT_GOLD, background: 'rgba(201,168,76,0.10)', border: '1px solid rgba(201,168,76,0.30)', borderRadius: 999, textDecoration: 'none', transition: 'all 120ms' }}
+            onMouseEnter={(ev) => { ev.currentTarget.style.background = 'rgba(201,168,76,0.20)' }}
+            onMouseLeave={(ev) => { ev.currentTarget.style.background = 'rgba(201,168,76,0.10)' }}
+          >
+            <span aria-hidden="true">🔗</span>
+            <span>Join</span>
+          </a>
+        )}
         {e.loc && <span style={{ fontSize: 11, color: ACCENT_TEAL }}>📍 {e.loc}</span>}
         {note && note.length > 0 && <span title="Has notes" style={{ fontSize: 11, color: ACCENT_GOLD }}>📝</span>}
         <span style={{ fontSize: 11, color: INK_DIM }}>{expanded ? '▾' : '▸'}</span>

--- a/src/components/today/OverlapBand.tsx
+++ b/src/components/today/OverlapBand.tsx
@@ -1,18 +1,13 @@
-// OverlapBand — placeholder for the side-by-side dashed band that renders
-// when two meetings collide on the timeline (CD spec — `timeToMin(a.time) <
-// timeToMin(b.end)` triggers the band).
+// OverlapBand — side-by-side dashed band that renders when two or more
+// meetings collide on the timeline. CD spec: detect via
+// `timeToMin(a.start) < timeToMin(b.end) && timeToMin(a.end) > timeToMin(b.start)`.
 //
-// Per HANDOFF §2 this component is "not implemented yet, leave as TODO."
-// Once Hub MeetingRow exposes `time` + `end` fields the Timeline can detect
-// overlap and pass colliding events here for grid layout.
-//
-// TODO: implement when calendar integration ships time + end on MeetingRow.
-//   - Accept `events: TodayEvent[]` (the colliding cluster).
-//   - Render a dashed-bordered "⚠ Overlap · N" header band.
-//   - Lay out events as a side-by-side grid using grid-template-columns:
-//     repeat(N, 1fr).
-//   - Forward onDismiss / onNote down to inner EventRow children.
+// TP-11 (Phase 39 audit): now implemented. Personal calendar feed events
+// carry startMin/endMin (constants.ts:calendarEventToTodayEvent), so Timeline
+// can group overlapping events into clusters and pass them here.
 
+import { EventRow } from './MeetingRow'
+import { ACCENT_CORAL, INK_DIM } from './constants'
 import type { TodayEvent } from './constants'
 
 interface OverlapBandProps {
@@ -22,9 +17,59 @@ interface OverlapBandProps {
   onNote: (id: string, v: string) => void
 }
 
-export function OverlapBand(_props: OverlapBandProps) {
-  // Intentionally returns null — the existing Timeline rendering path renders
-  // each meeting individually and does not yet detect overlap. Reintroduce
-  // this component when the calendar integration provides start + end times.
-  return null
+export function OverlapBand({ events, onDismiss, notes, onNote }: OverlapBandProps) {
+  if (events.length < 2) return null
+  return (
+    <div
+      role="group"
+      aria-label={`${events.length} overlapping events`}
+      style={{
+        position: 'relative',
+        padding: '8px 8px 6px',
+        margin: '4px 0',
+        border: `1px dashed ${ACCENT_CORAL}66`,
+        borderRadius: 8,
+        background: 'rgba(240,115,126,0.04)',
+      }}
+    >
+      <div
+        style={{
+          position: 'absolute',
+          top: -8,
+          left: 12,
+          padding: '1px 6px',
+          fontSize: 9,
+          fontWeight: 700,
+          letterSpacing: '0.10em',
+          textTransform: 'uppercase',
+          color: ACCENT_CORAL,
+          background: 'rgba(11,16,23,0.95)',
+          borderRadius: 3,
+        }}
+      >
+        ⚠ Overlap · {events.length}
+      </div>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${events.length}, minmax(0, 1fr))`,
+          gap: 6,
+        }}
+      >
+        {events.map((e) => (
+          <EventRow
+            key={e.id}
+            e={e}
+            overlap
+            onDismiss={onDismiss}
+            note={notes[e.id]}
+            onNote={onNote}
+          />
+        ))}
+      </div>
+      <div style={{ marginTop: 4, fontSize: 10, color: INK_DIM, fontStyle: 'italic' }}>
+        These events conflict — pick one or reschedule.
+      </div>
+    </div>
+  )
 }

--- a/src/components/today/PillStrip.tsx
+++ b/src/components/today/PillStrip.tsx
@@ -13,8 +13,18 @@ import {
 } from './constants'
 
 export function PillStrip({ counts }: { counts: DailyCounts }) {
-  const labHealth = Math.max(0, 100 - counts.overdue * 4 - counts.stalled * 2)
-  const healthColor = labHealth >= 85 ? ACCENT_GREEN : labHealth >= 70 ? ACCENT_GOLD : ACCENT_CORAL
+  // TP-17 (D20): sigmoid scaling — score = 100 / (1 + e^(0.05 * overdue + 0.02 * stalled)).
+  // Smooth degradation; never reaches 0. With 0/0 → 50, but the tooltip
+  // explains the formula so the number is legible. Old linear formula
+  // hit 0 at 25 overdue and stayed; sigmoid lets a 50-overdue lab still
+  // distinguish from a 5-overdue one.
+  const labHealth = Math.round(100 / (1 + Math.exp(0.05 * counts.overdue + 0.02 * counts.stalled)))
+  const healthColor = labHealth >= 35 ? ACCENT_GREEN : labHealth >= 25 ? ACCENT_GOLD : ACCENT_CORAL
+  const tooltipReasons: string[] = []
+  if (counts.overdue > 0) tooltipReasons.push(`${counts.overdue} overdue task${counts.overdue === 1 ? '' : 's'}`)
+  if (counts.stalled > 0) tooltipReasons.push(`${counts.stalled} stalled project${counts.stalled === 1 ? '' : 's'}`)
+  const tooltipReasonText = tooltipReasons.length > 0 ? tooltipReasons.join(' · ') : 'No active drag'
+  const tooltipText = `Lab Health: ${labHealth}/100\nFormula: 100 / (1 + e^(0.05·overdue + 0.02·stalled))\n${tooltipReasonText}\nClick for Lab Overview →`
   const scrollTo = (sel: string) => document.querySelector(sel)?.scrollIntoView({ behavior: 'smooth', block: 'start' })
 
   return (
@@ -27,7 +37,7 @@ export function PillStrip({ counts }: { counts: DailyCounts }) {
       <div style={{ flex: 1 }} />
       <Link
         to={PATHS.overview}
-        title="Lab Overview"
+        title={tooltipText}
         style={{ display: 'inline-flex', alignItems: 'center', gap: 10, padding: '7px 14px', background: `${healthColor}10`, border: `1px solid ${healthColor}50`, borderRadius: 999, textDecoration: 'none', transition: 'all 150ms' }}
         onMouseEnter={(e) => { e.currentTarget.style.background = `${healthColor}20` }}
         onMouseLeave={(e) => { e.currentTarget.style.background = `${healthColor}10` }}

--- a/src/components/today/TaskRow.tsx
+++ b/src/components/today/TaskRow.tsx
@@ -8,9 +8,38 @@
 import { ProjectLink } from './primitives'
 import { TaskDetailDrawer } from './TaskDetailDrawer'
 import { tagForTask } from './constants'
-import { ACCENT_GOLD, ACCENT_GREEN, INK, INK_DIM } from './constants'
+import { ACCENT_GOLD, ACCENT_GREEN, ACCENT_CORAL, ACCENT_ORANGE, INK, INK_DIM, INK_MUTED, todayKey } from './constants'
+import { formatRelativeTime, formatShortDate } from '../../lib/dateUtils'
 import type { TodayStateApi } from '../../hooks/useTodayState'
 import type { TaskRow as TaskRowData } from '../../lib/api'
+
+// Priority dot color (rule 59: maroon=urgent, orange=high, gold=medium,
+// slate=low). 'maroon' here uses the same coral tone TodayPage already
+// flags as urgency-warnings to stay inside the page's 5-accent palette.
+const PRIORITY_COLOR: Record<string, string> = {
+  urgent: ACCENT_CORAL,
+  high: ACCENT_ORANGE,
+  medium: ACCENT_GOLD,
+  low: '#7a828c',
+}
+
+// Tabular-nums short due-date label. Today / Tomorrow / Nd ago / in Nd /
+// fallback to "Mar 25" — same shape as InlineDatePicker preset labels.
+function dueLabel(due: string): string {
+  const todayStr = todayKey()
+  const dueDay = due.slice(0, 10)
+  if (dueDay === todayStr) return 'Today'
+  // Reuse formatRelativeTime for past dates ("2d ago"); future dates use
+  // a short "in 3d" form computed locally to avoid pulling another util.
+  const target = new Date(dueDay + 'T12:00:00')
+  const now = new Date()
+  const ms = target.getTime() - now.getTime()
+  const days = Math.round(ms / 86400000)
+  if (days === 1) return 'Tomorrow'
+  if (days >= -7 && days < 0) return formatRelativeTime(due)
+  if (days > 0 && days <= 7) return `in ${days}d`
+  return formatShortDate(due)
+}
 
 export function TaskRow({ task, project, state, expandedId, onExpand, projectsByPid }: { task: TaskRowData; project: { name: string; slug: string } | null; state: TodayStateApi; expandedId: string | null; onExpand: (id: string) => void; projectsByPid: Map<string, { name: string; slug: string; category?: string | null }> }) {
   const isDone = !!state.done[task.id]
@@ -18,12 +47,36 @@ export function TaskRow({ task, project, state, expandedId, onExpand, projectsBy
   const planned = state.planned[task.id]
   const expanded = expandedId === task.id
   const tag = tagForTask(task, projectsByPid)
+  const priorityColor = task.priority ? PRIORITY_COLOR[task.priority] : null
+  // Due date: overdue if cmp(due, today) < 0 (string compare on YYYY-MM-DD).
+  const due = task.due_date
+  const isOverdue = !!due && due.slice(0, 10) < todayKey()
+  const dueColor = isOverdue ? ACCENT_CORAL : (due && due.slice(0, 10) === todayKey() ? ACCENT_GOLD : INK_MUTED)
   const onDragStart = (e: React.DragEvent) => {
     e.dataTransfer.effectAllowed = 'move'
     e.dataTransfer.setData('text/plain', task.id)
   }
   return (
-    <div style={{ borderBottom: '1px solid rgba(255,255,255,0.04)', background: isNow ? 'rgba(201,168,76,0.05)' : (isDone ? 'rgba(110,232,154,0.02)' : 'transparent'), opacity: isDone ? 0.6 : 1, transition: 'background 220ms' }}>
+    <div style={{ borderBottom: '1px solid rgba(255,255,255,0.04)', background: isNow ? 'rgba(201,168,76,0.05)' : (isDone ? 'rgba(110,232,154,0.02)' : 'transparent'), opacity: isDone ? 0.6 : 1, transition: 'background 220ms', position: 'relative' }}>
+      {/* TP-12: 4px priority dot on the left edge — color-codes urgency
+          without taking column space. Anchored vs the row's gutter so it
+          aligns regardless of checkbox/grip column width. */}
+      {priorityColor && !isDone && (
+        <span
+          aria-hidden="true"
+          title={`Priority: ${task.priority}`}
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            width: 4,
+            height: 24,
+            background: priorityColor,
+            borderRadius: '0 2px 2px 0',
+          }}
+        />
+      )}
       <div onClick={() => !isDone && onExpand(task.id)} style={{ display: 'flex', gap: 0, alignItems: 'stretch', padding: 0, cursor: isDone ? 'default' : 'pointer' }}>
         <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '10px 10px', gap: 4, borderRight: '1px solid rgba(255,255,255,0.03)' }} onClick={(e) => e.stopPropagation()}>
           <input
@@ -48,7 +101,26 @@ export function TaskRow({ task, project, state, expandedId, onExpand, projectsBy
             {planned && !isDone && (
               <span style={{ fontSize: 10, color: ACCENT_GOLD, padding: '1px 6px', background: 'rgba(201,168,76,0.10)', borderRadius: 3, letterSpacing: '0.04em' }}>📌 {planned.slot === 'strip' ? 'planned' : 'scheduled'}</span>
             )}
-            {!isDone && <span style={{ marginLeft: 'auto', fontSize: 11, color: INK_DIM }}>{expanded ? '▾' : '▸'}</span>}
+            {/* TP-12: tabular-nums right-aligned due-date cell. Coral when
+                overdue, gold when today, muted otherwise. */}
+            {due && !isDone && (
+              <span
+                title={`Due ${due.slice(0, 10)}`}
+                style={{
+                  marginLeft: 'auto',
+                  fontSize: 11,
+                  color: dueColor,
+                  fontVariantNumeric: 'tabular-nums',
+                  fontWeight: isOverdue ? 600 : 500,
+                  flexShrink: 0,
+                }}
+              >
+                {dueLabel(due)}
+              </span>
+            )}
+            {!isDone && (
+              <span style={{ marginLeft: due ? 0 : 'auto', fontSize: 11, color: INK_DIM, flexShrink: 0 }}>{expanded ? '▾' : '▸'}</span>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/today/Timeline.tsx
+++ b/src/components/today/Timeline.tsx
@@ -6,17 +6,35 @@
 //
 // Extracted from src/pages/portal/TodayPage.tsx (B2_Timeline + DropZone).
 
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { PATHS } from '../../constants/paths'
 import { EventRow } from './MeetingRow'
 import { PlannedTaskRow } from './PlannedTaskRow'
 import {
-  ACCENT_GOLD, ACCENT_TEAL, INK_MUTED, INK_DIM,
+  ACCENT_GOLD, ACCENT_TEAL, ACCENT_CORAL, INK_MUTED, INK_DIM,
   type PlannedSlot, type TodayEvent,
 } from './constants'
 import type { TodayStateApi } from '../../hooks/useTodayState'
 import type { TaskRow } from '../../lib/api'
+
+// TP-09: 1px now-line. Updates every 60s via setInterval. Static — no
+// animation — so prefers-reduced-motion is a no-op.
+function useNowMinutes(): number {
+  const [now, setNow] = useState(() => {
+    const d = new Date()
+    return d.getHours() * 60 + d.getMinutes()
+  })
+  useEffect(() => {
+    const tick = () => {
+      const d = new Date()
+      setNow(d.getHours() * 60 + d.getMinutes())
+    }
+    const id = setInterval(tick, 60_000)
+    return () => clearInterval(id)
+  }, [])
+  return now
+}
 
 function DropZone({ slot, label, onDropTask }: { slot: PlannedSlot; label: string; onDropTask: (id: string, slot: PlannedSlot) => void }) {
   return (
@@ -52,6 +70,47 @@ export function Timeline({ events, tasks, state, projectsByPid, expandedId, onEx
   const visibleMeetings = events.filter((e) => !dismissedMeetings[e.id])
   const onDropTask = useCallback((id: string, slot: PlannedSlot) => state.planAt(id, slot), [state])
 
+  // TP-09: now-line. Window = min(startMin) of timed events to max(endMin),
+  // clamped + padded to a sensible 7am-8pm default if no timed events.
+  // Line color = coral if user is currently inside a meeting, gold otherwise
+  // (Rule 59 — coral = warnings/overlap, gold = user-driven action).
+  const now = useNowMinutes()
+  const meetingsListRef = useRef<HTMLDivElement | null>(null)
+  const [listHeight, setListHeight] = useState(0)
+  useEffect(() => {
+    const el = meetingsListRef.current
+    if (!el) return
+    const update = () => setListHeight(el.offsetHeight)
+    update()
+    const obs = new ResizeObserver(update)
+    obs.observe(el)
+    return () => obs.disconnect()
+  }, [visibleMeetings.length])
+  const { dayStart, dayEnd, inMeeting, lineTop } = useMemo(() => {
+    const timed = visibleMeetings
+      .map((e) => ({ start: e.startMin, end: e.endMin }))
+      .filter((t): t is { start: number; end: number | undefined } => typeof t.start === 'number')
+    let ds = 7 * 60   // 7:00 default
+    let de = 20 * 60  // 20:00 default
+    if (timed.length > 0) {
+      const minStart = Math.min(...timed.map((t) => t.start))
+      const maxEnd = Math.max(...timed.map((t) => (typeof t.end === 'number' ? t.end : t.start + 30)))
+      ds = Math.min(ds, minStart - 30)
+      de = Math.max(de, maxEnd + 30)
+    }
+    const inMtg = visibleMeetings.some((e) => typeof e.startMin === 'number' && typeof e.endMin === 'number' && e.startMin <= now && now < e.endMin)
+    const fraction = listHeight > 0 && de > ds && now >= ds && now <= de
+      ? (now - ds) / (de - ds)
+      : -1
+    const top = fraction >= 0 ? Math.round(fraction * listHeight) : -1
+    return { dayStart: ds, dayEnd: de, inMeeting: inMtg, lineTop: top }
+  }, [visibleMeetings, now, listHeight])
+  const showLine = lineTop >= 0
+  const nowColor = inMeeting ? ACCENT_CORAL : ACCENT_GOLD
+  const nowLabel = `${String(Math.floor(now / 60)).padStart(2, '0')}:${String(now % 60).padStart(2, '0')}`
+  // Suppress unused-var warning for derived window; kept in scope for future work.
+  void dayStart; void dayEnd
+
   const plannedStripIds = state.plannedIds().filter((id) => state.planned[id]?.slot === 'strip' && id !== state.rightNow)
   const plannedStripTasks = plannedStripIds.map((id) => tasks.find((t) => t.id === id)).filter((t): t is TaskRow => !!t)
 
@@ -71,7 +130,53 @@ export function Timeline({ events, tasks, state, projectsByPid, expandedId, onEx
           <Link to={PATHS.settings} style={{ fontSize: 11, color: ACCENT_TEAL, textDecoration: 'underline' }}>Connect a calendar in Settings</Link>
         </div>
       )}
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <div ref={meetingsListRef} style={{ display: 'flex', flexDirection: 'column', gap: 4, position: 'relative' }}>
+        {showLine && (
+          <div
+            aria-hidden="true"
+            style={{
+              position: 'absolute',
+              left: 0,
+              right: 0,
+              top: lineTop,
+              height: 1,
+              background: nowColor,
+              pointerEvents: 'none',
+              zIndex: 2,
+              boxShadow: `0 0 4px ${nowColor}80`,
+            }}
+          >
+            <span
+              style={{
+                position: 'absolute',
+                left: -4,
+                top: -3,
+                width: 7,
+                height: 7,
+                borderRadius: '50%',
+                background: nowColor,
+              }}
+            />
+            <span
+              title={inMeeting ? 'Currently in a meeting' : 'Now'}
+              style={{
+                position: 'absolute',
+                right: 0,
+                top: -7,
+                padding: '1px 5px',
+                fontSize: 9,
+                fontWeight: 700,
+                letterSpacing: '0.08em',
+                textTransform: 'uppercase',
+                color: nowColor,
+                background: 'rgba(11,16,23,0.90)',
+                borderRadius: 3,
+              }}
+            >
+              {nowLabel} now
+            </span>
+          </div>
+        )}
         {visibleMeetings.map((e, idx) => {
           // Gather planned tasks dropped into the gap BEFORE this meeting.
           const slotKey = `between-${idx}` as PlannedSlot

--- a/src/components/today/Timeline.tsx
+++ b/src/components/today/Timeline.tsx
@@ -10,6 +10,7 @@ import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
 import { PATHS } from '../../constants/paths'
 import { EventRow } from './MeetingRow'
+import { OverlapBand } from './OverlapBand'
 import { PlannedTaskRow } from './PlannedTaskRow'
 import {
   ACCENT_GOLD, ACCENT_TEAL, ACCENT_CORAL, INK_MUTED, INK_DIM,
@@ -111,6 +112,35 @@ export function Timeline({ events, tasks, state, projectsByPid, expandedId, onEx
   // Suppress unused-var warning for derived window; kept in scope for future work.
   void dayStart; void dayEnd
 
+  // TP-11: cluster overlapping events. Walk events sorted by startMin and
+  // merge any whose startMin < cluster.maxEnd into the running cluster.
+  // Untimed events (no startMin) never overlap — each forms a singleton.
+  const clusters = useMemo(() => {
+    const result: TodayEvent[][] = []
+    const timed = visibleMeetings.filter((e) => typeof e.startMin === 'number')
+    const untimed = visibleMeetings.filter((e) => typeof e.startMin !== 'number')
+    // Untimed events keep insertion order, each as a 1-event cluster.
+    for (const e of untimed) result.push([e])
+    // Timed events: sort by start, then cluster by overlap.
+    const sorted = [...timed].sort((a, b) => (a.startMin ?? 0) - (b.startMin ?? 0))
+    let current: TodayEvent[] = []
+    let currentEnd = -1
+    for (const e of sorted) {
+      const s = e.startMin as number
+      const en = typeof e.endMin === 'number' ? e.endMin : s + 30
+      if (current.length === 0 || s < currentEnd) {
+        current.push(e)
+        currentEnd = Math.max(currentEnd, en)
+      } else {
+        result.push(current)
+        current = [e]
+        currentEnd = en
+      }
+    }
+    if (current.length > 0) result.push(current)
+    return result
+  }, [visibleMeetings])
+
   const plannedStripIds = state.plannedIds().filter((id) => state.planned[id]?.slot === 'strip' && id !== state.rightNow)
   const plannedStripTasks = plannedStripIds.map((id) => tasks.find((t) => t.id === id)).filter((t): t is TaskRow => !!t)
 
@@ -177,16 +207,19 @@ export function Timeline({ events, tasks, state, projectsByPid, expandedId, onEx
             </span>
           </div>
         )}
-        {visibleMeetings.map((e, idx) => {
-          // Gather planned tasks dropped into the gap BEFORE this meeting.
+        {clusters.map((cluster, idx) => {
+          // Gather planned tasks dropped into the gap BEFORE this cluster.
           const slotKey = `between-${idx}` as PlannedSlot
           const tasksInGap = state.plannedIds()
             .filter((id) => state.planned[id]?.slot === slotKey)
             .map((id) => tasks.find((t) => t.id === id))
             .filter((t): t is TaskRow => !!t)
+          const head = cluster[0]
+          const beforeLabel = `drop a task here · before ${head.title}${cluster.length > 1 ? ` (+${cluster.length - 1} overlap)` : ''}`
+          const clusterKey = cluster.map((e) => e.id).join('|')
           return (
-            <div key={e.id}>
-              <DropZone slot={slotKey} label={`drop a task here · before ${e.title}`} onDropTask={onDropTask} />
+            <div key={clusterKey}>
+              <DropZone slot={slotKey} label={beforeLabel} onDropTask={onDropTask} />
               {tasksInGap.map((t) => (
                 <PlannedTaskRow
                   key={t.id}
@@ -199,17 +232,26 @@ export function Timeline({ events, tasks, state, projectsByPid, expandedId, onEx
                   projectsByPid={projectsByPid}
                 />
               ))}
-              <EventRow
-                e={e}
-                onDismiss={(id) => setDismissedMeetings((s) => ({ ...s, [id]: true }))}
-                note={meetingNotes[e.id]}
-                onNote={(id, v) => setMeetingNotes((s) => ({ ...s, [id]: v }))}
-              />
+              {cluster.length === 1 ? (
+                <EventRow
+                  e={head}
+                  onDismiss={(id) => setDismissedMeetings((s) => ({ ...s, [id]: true }))}
+                  note={meetingNotes[head.id]}
+                  onNote={(id, v) => setMeetingNotes((s) => ({ ...s, [id]: v }))}
+                />
+              ) : (
+                <OverlapBand
+                  events={cluster}
+                  onDismiss={(id) => setDismissedMeetings((s) => ({ ...s, [id]: true }))}
+                  notes={meetingNotes}
+                  onNote={(id, v) => setMeetingNotes((s) => ({ ...s, [id]: v }))}
+                />
+              )}
             </div>
           )
         })}
-        {visibleMeetings.length > 0 && (() => {
-          const slotKey = `between-${visibleMeetings.length}` as PlannedSlot
+        {clusters.length > 0 && (() => {
+          const slotKey = `between-${clusters.length}` as PlannedSlot
           const tasksInGap = state.plannedIds()
             .filter((id) => state.planned[id]?.slot === slotKey)
             .map((id) => tasks.find((t) => t.id === id))

--- a/src/components/today/constants.ts
+++ b/src/components/today/constants.ts
@@ -29,6 +29,16 @@ export interface TodayEvent {
   title: string
   loc?: string
   href?: string
+  // Phase 39 audit (TP-10): meeting URL extracted by ics-parser. Surfaces
+  // as the "🔗 Join" chip on the EventRow when present. Sourced from the
+  // event's location field via classifyMeetingUrl().
+  meetingUrl?: string
+  // Phase 39 audit (TP-09 + TP-11): wall-clock minutes since midnight
+  // (local). Used for now-line rendering + overlap detection. Populated
+  // from the iCal startAt/endAt; legacy team meetings (date-only) leave
+  // these undefined and render as untimed.
+  startMin?: number
+  endMin?: number
 }
 
 export interface DailyCounts {
@@ -151,6 +161,30 @@ export function meetingToEvent(m: MeetingRow): TodayEvent {
   return { id: m.id, time: '—', title: m.title }
 }
 
+// TP-10: detect a meeting URL in the location field. ics-parser already
+// runs enrichLocation() which folds Zoom/Teams/Meet URLs from DESCRIPTION
+// into LOCATION. We just need to recognise an http(s) URL here.
+const MEETING_URL_RE = /^https?:\/\/\S+/i
+
+export function extractMeetingUrl(location: string | null | undefined): string | undefined {
+  if (!location) return undefined
+  const trimmed = location.trim()
+  if (MEETING_URL_RE.test(trimmed)) return trimmed
+  // Also handle "<text> <url>" — pick first URL substring.
+  const m = trimmed.match(/https?:\/\/\S+/)
+  return m ? m[0] : undefined
+}
+
+// TP-09 + TP-11: minutes-since-midnight from an ISO timestamp, in the
+// browser's local TZ. Returns undefined for all-day events (no clock
+// position to report).
+export function localMinutesFromIso(iso: string | null | undefined): number | undefined {
+  if (!iso) return undefined
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return undefined
+  return d.getHours() * 60 + d.getMinutes()
+}
+
 export function isToday(isoDate: string | null | undefined): boolean {
   if (!isoDate) return false
   const today = todayKey()
@@ -168,11 +202,18 @@ export function calendarEventToTodayEvent(e: { id: string; title: string; locati
   const end = e.endAt && !e.isAllDay
     ? new Date(e.endAt).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
     : undefined
+  const meetingUrl = extractMeetingUrl(e.location)
+  // If location holds a meeting URL, hide the URL string from the loc
+  // chip (it'll render via the dedicated 🔗 Join button instead).
+  const loc = meetingUrl ? undefined : (e.location ?? undefined)
   return {
     id: `cal-${e.id}`,
     time,
     end,
     title: e.title,
-    loc: e.location ?? undefined,
+    loc,
+    meetingUrl,
+    startMin: e.isAllDay ? undefined : localMinutesFromIso(e.startAt),
+    endMin: e.isAllDay ? undefined : localMinutesFromIso(e.endAt),
   }
 }

--- a/src/components/today/rail/HermesSuggestsCard.tsx
+++ b/src/components/today/rail/HermesSuggestsCard.tsx
@@ -1,7 +1,14 @@
-// HermesSuggestsCard — algorithmic 3-bullet focus suggestion (CD spec).
+// HermesSuggestsCard ("Today's Focus") — algorithmic 3-bullet suggestion.
 // First bullet biased to longest-overdue task, second to most-stalled
 // project, third to mentee with soonest due. Real Hermes (async ai_request)
-// is a follow-up — see HANDOFF Phase 2.
+// is a follow-up — D17 stage 2.
+//
+// TP-14 (D17 stage 1, Phase 39 audit): renamed from "Hermes Suggests" to
+// "Today's Focus" because the heuristic is JS, not an LLM call. The ✨
+// glyph and gold-AI framing implied AI authorship that wasn't there. We
+// keep the heuristic as-is; stage 2 will swap to a 1×/day cached
+// ai_request. The component name + filename keep "HermesSuggests" to
+// minimise churn on imports — only the visible label changes.
 //
 // Extracted from src/pages/portal/TodayPage.tsx (B2_Rail_Alert).
 
@@ -54,8 +61,8 @@ export function HermesSuggestsCard({ overdueTasks, stalledProjects, menteesWithD
   return (
     <div style={{ padding: 14, background: 'rgba(201,168,76,0.06)', border: '1px solid rgba(201,168,76,0.20)', borderRadius: 6, marginBottom: 14 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
-        <span>✨</span>
-        <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.10em', textTransform: 'uppercase', color: ACCENT_GOLD }}>Hermes suggests</span>
+        <span style={{ width: 6, height: 6, borderRadius: '50%', background: ACCENT_GOLD }} />
+        <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.10em', textTransform: 'uppercase', color: ACCENT_GOLD }}>Today's focus</span>
       </div>
       <div style={{ fontSize: 12, color: INK, lineHeight: 1.5, marginBottom: 8 }}>{focus}</div>
       <ul style={{ margin: 0, paddingLeft: 14, fontSize: 11, color: INK_MUTED, lineHeight: 1.7 }}>

--- a/src/components/today/rail/NeedsAttentionCard.tsx
+++ b/src/components/today/rail/NeedsAttentionCard.tsx
@@ -4,10 +4,17 @@
 //
 // Extracted from src/pages/portal/TodayPage.tsx (B2_Rail_Attention).
 
+import { Link } from 'react-router-dom'
 import { ACCENT_CORAL, ACCENT_ORANGE, INK, INK_DIM, daysSince } from '../constants'
+import { PATHS } from '../../../constants/paths'
 import type { TaskRow } from '../../../lib/api'
 
 export function NeedsAttentionCard({ overdueTasks, stalledProjects }: { overdueTasks: TaskRow[]; stalledProjects: Array<{ name: string; days: number }> }) {
+  // TP-18: when more than 5 in either bucket, append a "+N more →" link
+  // that filters MyTasks (overdue) / Projects (stalled) to the matching
+  // subset. Keeps top-5 readable without burying the long-tail count.
+  const overdueExtra = Math.max(0, overdueTasks.length - 5)
+  const stalledExtra = Math.max(0, stalledProjects.length - 5)
   return (
     <div data-b2-attention style={{ marginBottom: 14 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
@@ -28,6 +35,16 @@ export function NeedsAttentionCard({ overdueTasks, stalledProjects }: { overdueT
             </div>
           )
         })}
+        {overdueExtra > 0 && (
+          <Link
+            to={`${PATHS.myTasks}?filter=overdue`}
+            style={{ display: 'inline-block', marginTop: 6, fontSize: 11, color: ACCENT_CORAL, textDecoration: 'none', fontWeight: 500 }}
+            onMouseEnter={(e) => { e.currentTarget.style.textDecoration = 'underline' }}
+            onMouseLeave={(e) => { e.currentTarget.style.textDecoration = 'none' }}
+          >
+            +{overdueExtra} more →
+          </Link>
+        )}
       </div>
       <div style={{ padding: 12, background: 'rgba(240,138,91,0.04)', border: '1px solid rgba(240,138,91,0.15)', borderRadius: 6 }}>
         <div style={{ fontSize: 10, color: ACCENT_ORANGE, marginBottom: 4, fontWeight: 600, letterSpacing: '0.04em' }}>STALLED</div>
@@ -40,6 +57,16 @@ export function NeedsAttentionCard({ overdueTasks, stalledProjects }: { overdueT
             <span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
           </div>
         ))}
+        {stalledExtra > 0 && (
+          <Link
+            to={`${PATHS.projects}?filter=stalled`}
+            style={{ display: 'inline-block', marginTop: 6, fontSize: 11, color: ACCENT_ORANGE, textDecoration: 'none', fontWeight: 500 }}
+            onMouseEnter={(e) => { e.currentTarget.style.textDecoration = 'underline' }}
+            onMouseLeave={(e) => { e.currentTarget.style.textDecoration = 'none' }}
+          >
+            +{stalledExtra} more →
+          </Link>
+        )}
       </div>
     </div>
   )

--- a/src/components/today/rail/ProjectsCard.tsx
+++ b/src/components/today/rail/ProjectsCard.tsx
@@ -1,26 +1,57 @@
 // ProjectsCard — searchable project list w/ next-action cue.
-// Filter input narrows by name (substring); shows up to 12.
+//
+// TP-19 (D21): default filter narrows to "relevant today" projects —
+// those with (tasks due today OR overdue) OR (planned-today tasks) OR
+// (last-7d activity). User can toggle "Show all" to expand to the full
+// active list. Toggle state persists in localStorage.today_projects_show_all.
 //
 // Extracted from src/pages/portal/TodayPage.tsx (B2_Rail_Projects).
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { PATHS } from '../../../constants/paths'
-import { ACCENT_TEAL, INK, INK_MUTED, INK_DIM } from '../constants'
+import { ACCENT_TEAL, ACCENT_GOLD, INK, INK_MUTED, INK_DIM } from '../constants'
 
-export function ProjectsCard({ projects }: { projects: Array<{ slug: string; name: string; nextAction?: string | null }> }) {
+const SHOW_ALL_KEY = 'today_projects_show_all'
+
+interface ProjectEntry {
+  slug: string
+  name: string
+  nextAction?: string | null
+  relevantToday?: boolean
+}
+
+export function ProjectsCard({ projects }: { projects: ProjectEntry[] }) {
   const [q, setQ] = useState('')
+  const [showAll, setShowAll] = useState<boolean>(() => {
+    try { return window.localStorage.getItem(SHOW_ALL_KEY) === '1' } catch { return false }
+  })
+  useEffect(() => {
+    try { window.localStorage.setItem(SHOW_ALL_KEY, showAll ? '1' : '0') } catch { /* ignore */ }
+  }, [showAll])
+
+  const relevantCount = useMemo(() => projects.filter((p) => p.relevantToday).length, [projects])
+  const totalCount = projects.length
+  // If no project is flagged relevant (e.g. blank Friday), fall back to
+  // showing all so the card isn't an empty rail. The toggle still reads
+  // 'Show all' since the default-collapsed state already shows them.
+  const noRelevantFlagged = relevantCount === 0
+  const useAll = showAll || noRelevantFlagged
+
   const shown = useMemo(() => {
-    const filtered = q ? projects.filter((p) => p.name.toLowerCase().includes(q.toLowerCase())) : projects
+    const base = useAll ? projects : projects.filter((p) => p.relevantToday)
+    const filtered = q ? base.filter((p) => p.name.toLowerCase().includes(q.toLowerCase())) : base
     return filtered.slice(0, 12)
-  }, [projects, q])
+  }, [projects, q, useAll])
 
   return (
     <div style={{ marginBottom: 14 }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
         <span style={{ width: 6, height: 6, borderRadius: '50%', background: ACCENT_TEAL }} />
         <h4 style={{ fontSize: 10, fontWeight: 700, letterSpacing: '0.10em', textTransform: 'uppercase', color: ACCENT_TEAL, margin: 0 }}>Projects</h4>
-        <span style={{ fontSize: 11, color: INK_DIM, marginLeft: 'auto' }}>{projects.length}</span>
+        <span style={{ fontSize: 11, color: INK_DIM, marginLeft: 'auto' }}>
+          {useAll ? totalCount : `${relevantCount} today`}
+        </span>
       </div>
       <input
         value={q}
@@ -29,10 +60,18 @@ export function ProjectsCard({ projects }: { projects: Array<{ slug: string; nam
         style={{ width: '100%', padding: '6px 10px', background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 4, fontSize: 12, color: INK, outline: 'none', fontFamily: 'inherit', marginBottom: 8, boxSizing: 'border-box' }}
       />
       <div style={{ maxHeight: 320, overflowY: 'auto' }}>
+        {shown.length === 0 && (
+          <div style={{ padding: '8px 4px', fontSize: 11, color: INK_DIM, fontStyle: 'italic' }}>
+            {q ? 'No matches.' : useAll ? 'No active projects.' : 'No projects with activity today — toggle Show all.'}
+          </div>
+        )}
         {shown.map((p) => (
           <Link key={p.slug} to={PATHS.project(p.slug)} className="b2-proj" style={{ display: 'block', padding: 8, borderRadius: 4, textDecoration: 'none' }}>
             <div style={{ display: 'flex', alignItems: 'baseline', gap: 6, marginBottom: 2 }}>
               <span style={{ fontSize: 12, color: INK, fontWeight: 500, flex: 1, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{p.name}</span>
+              {p.relevantToday && !useAll && (
+                <span title="Active today" aria-hidden="true" style={{ width: 4, height: 4, borderRadius: '50%', background: ACCENT_GOLD, flexShrink: 0 }} />
+              )}
             </div>
             {p.nextAction && (
               <div style={{ fontSize: 11, color: INK_MUTED, opacity: 0.8, paddingLeft: 0, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>→ {p.nextAction}</div>
@@ -40,6 +79,26 @@ export function ProjectsCard({ projects }: { projects: Array<{ slug: string; nam
           </Link>
         ))}
       </div>
+      {!noRelevantFlagged && totalCount > relevantCount && (
+        <button
+          type="button"
+          onClick={() => setShowAll((v) => !v)}
+          style={{
+            marginTop: 8,
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            color: ACCENT_TEAL,
+            fontSize: 11,
+            cursor: 'pointer',
+            fontFamily: 'inherit',
+          }}
+          onMouseEnter={(e) => { e.currentTarget.style.textDecoration = 'underline' }}
+          onMouseLeave={(e) => { e.currentTarget.style.textDecoration = 'none' }}
+        >
+          {showAll ? `Show today only (${relevantCount})` : `Show all (${totalCount})`}
+        </button>
+      )}
     </div>
   )
 }

--- a/src/pages/portal/TodayPage.tsx
+++ b/src/pages/portal/TodayPage.tsx
@@ -123,6 +123,11 @@ export default function TodayPage() {
     // Per-project: soonest-due open task assigned to current user, used as
     // the "next action" cue. No dedicated column on projects, so derive.
     const nextByProject = new Map<string, { title: string; due: string | null }>()
+    // TP-19 (D21): "relevant today" = project has tasks due today/overdue
+    // OR a planned-today task OR last activity within 7 days.
+    const today = todayKey()
+    const sevenDaysAgoMs = Date.now() - 7 * 86400000
+    const relevantSlugs = new Set<string>()
     for (const t of allTasks) {
       if (t.completed === 1 || t.status === 'done') continue
       if (!t.project_id) continue
@@ -131,14 +136,28 @@ export default function TodayPage() {
       const aDue = t.due_date ?? '9999-12-31'
       const eDue = existing?.due ?? '9999-12-31'
       if (!existing || aDue < eDue) nextByProject.set(t.project_id, { title: t.title, due: t.due_date ?? null })
+      // Relevance signal A: due today OR overdue.
+      if (t.due_date && t.due_date.slice(0, 10) <= today) relevantSlugs.add(t.project_id)
+      // Relevance signal B: planned-today (covers strip and between-N slots).
+      if (state.planned[t.id]) relevantSlugs.add(t.project_id)
     }
     return all
       .filter((p) => p.status === 'Active')
       .map((p) => {
         const next = nextByProject.get(p.slug)
-        return { slug: p.slug, name: p.title ?? p.slug, nextAction: next ? next.title.slice(0, 80) : null }
+        // Relevance signal C: lastActivity within 7d.
+        if (p.lastActivity) {
+          const t = new Date(p.lastActivity).getTime()
+          if (!isNaN(t) && t >= sevenDaysAgoMs) relevantSlugs.add(p.slug)
+        }
+        return {
+          slug: p.slug,
+          name: p.title ?? p.slug,
+          nextAction: next ? next.title.slice(0, 80) : null,
+          relevantToday: relevantSlugs.has(p.slug),
+        }
       })
-  }, [projectsQuery.data, tasksQuery.data, userSlug])
+  }, [projectsQuery.data, tasksQuery.data, userSlug, state])
 
   const milestones = useMemo(() => {
     const reg = regulatoryQuery.data ?? []

--- a/src/pages/portal/TodayPage.tsx
+++ b/src/pages/portal/TodayPage.tsx
@@ -11,7 +11,7 @@
 // explicit ▶ button = promote (Rule 58).
 
 import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
-import { useTasks, useProjects, useMeetingsApi, useExpiringRegulatory, useUserCalendarEvents } from '../../hooks/useApiData'
+import { useTasks, useProjects, useMeetingsApi, useExpiringRegulatory, useUserCalendarEvents, usePBSessionStats } from '../../hooks/useApiData'
 import { useAuth } from '../../hooks/useAuth'
 import { emailToSlug } from '../../lib/emailSlug'
 import { usePageMeta } from '../../hooks/usePageMeta'
@@ -49,6 +49,9 @@ export default function TodayPage() {
   const meetingsQuery = useMeetingsApi()
   const regulatoryQuery = useExpiringRegulatory(60)
   const calendarEventsQuery = useUserCalendarEvents()
+  // TP-16 (D19): focusMin reads from real PB pomodoro sessions instead of
+  // the prior fake `plannedIds × 30` math. Returns 0 if no sessions today.
+  const sessionStatsQuery = usePBSessionStats()
 
   const tasks: TaskRow[] = useMemo(() => (tasksQuery.data ?? []).filter((t) => t.completed === 0 && t.status !== 'done'), [tasksQuery.data])
 
@@ -142,10 +145,16 @@ export default function TodayPage() {
     return reg.map((r: any) => ({ title: r.name ?? r.title ?? 'Regulatory item', days: r.days_until_expiry ?? 0 })).filter((m: { days: number }) => m.days > 0).sort((a: { days: number }, b: { days: number }) => a.days - b.days).slice(0, 5)
   }, [regulatoryQuery.data])
 
-  // Pulse: focus minutes proxy (planned tasks × 30min average), sync staleness, mentees.
-  // Mentees = researchTeam slugs (Coordinators / Fellows / Students / Analysts).
-  // Each mentee's "next" is the soonest due_date among their assigned tasks; — if none.
-  const focusMin = useMemo(() => state.plannedIds().length * 30, [state])
+  // Pulse: real focus minutes from PB pomodoro sessions today (D19),
+  // sync staleness, mentees. Mentees = researchTeam slugs (Coordinators /
+  // Fellows / Students / Analysts). Each mentee's "next" is the soonest
+  // due_date among their assigned tasks; — if none.
+  const focusMin = useMemo(() => {
+    const today = todayKey()
+    const perDay = sessionStatsQuery.data?.per_day ?? []
+    const todayRow = perDay.find((d) => d.day === today)
+    return todayRow?.total_minutes ?? 0
+  }, [sessionStatsQuery.data])
   const syncHours = useMemo(() => hoursSinceLastSync(), [])
   const mentees = useMemo(() => {
     const allTasks = tasksQuery.data ?? []


### PR DESCRIPTION
Wave 4. TodayPage Tier-1 polish — now-line, Join button, OverlapBand, due/priority cells, sigmoid Lab Health, focusMin from PB, etc. Build clean.

## Closes (9/9)

- **TP-09** (P1, D15) — 1px now-line at `(currentTime - dayStart) / dayLength`. `useNowMinutes()` 60s ticker + ResizeObserver. Coral if user in meeting; gold otherwise.
- **TP-10** (P1) — '🔗 Join' chip on EventRow when iCal `meetingUrl` present (Zoom/Teams/Meet). `useUserCalendarEvents` already enriches via `enrichLocation`.
- **TP-11** (P1) — OverlapBand implemented (was stub). Cluster events whose start < cluster.maxEnd; render dashed coral band w/ side-by-side grid.
- **TP-12** (P1) — TaskRow due-date cell (tabular-nums right-aligned, coral if overdue) + 4px priority dot on left edge (maroon urgent / orange high / gold medium / slate low).
- **TP-14** (P1, D17) — 'Hermes Suggests' renamed → 'Today's Focus'; ✨ swapped for 6px gold dot. Stage 1 of D17 (real Hermes wire is Stage 2).
- **TP-16** (P1, D19) — focusMin wired to `usePBSessionStats` (already used by PomodoroStatsCard). Sums today's PB session minutes. Drops fake `plannedIds × 30` math.
- **TP-17** (P1, D20) — Lab Health sigmoid: `100 / (1 + Math.exp(0.05 × overdue + 0.02 × stalled))`. Color thresholds retuned (≥35 green, ≥25 gold). Tooltip explains formula + reasons.
- **TP-18** (P1) — NeedsAttention top-5 truncation now appends '+N more →' link to `/portal/my-tasks?filter=overdue` and `/portal/projects?filter=stalled`.
- **TP-19** (P1, D21) — ProjectsCard 'relevant today' default filter (due-today OR planned OR last-7d activity) + 'Show all (N)' toggle persisted to `localStorage.today_projects_show_all`.

## Pattern surprises

- **Carrying `meetingUrl` + `startMin`/`endMin` on `TodayEvent` unlocked three findings at once.** TP-10 → TP-09 → TP-11 stacked on the same data plumbing.
- **Drop-zone slot indices reflowed from per-event to per-cluster** (TP-11). Presentation-only — `today_state_*` planned-slot persistence migrates naturally.
- **PillStrip thresholds re-tuned for sigmoid** (TP-17). Old (≥85 green / ≥70 gold) never fires because sigmoid bounds healthy labs at 40-50.
- **`useUserCalendarEvents` already enriches location with meeting URL** via `enrichLocation` in `api/lib/ics-parser.ts`. No backend/schema change needed for TP-10.

## Tier-2 explicitly skipped per brief
TP-04 / TP-05 / TP-06 / TP-13 / TP-15 — separate bundles.

## Files

- `src/components/today/constants.ts` — extended TodayEvent shape
- `src/components/today/MeetingRow.tsx` — Join chip
- `src/components/today/Timeline.tsx` — now-line + cluster integration
- `src/components/today/OverlapBand.tsx` — full implementation
- `src/components/today/TaskRow.tsx` — priority dot + due cell
- `src/components/today/PillStrip.tsx` — sigmoid + tooltip
- `src/components/today/rail/HermesSuggestsCard.tsx` — rename
- `src/components/today/rail/NeedsAttentionCard.tsx` — overflow links
- `src/components/today/rail/ProjectsCard.tsx` — relevantToday filter
- `src/pages/portal/TodayPage.tsx` — wire-ups
- `audit/2026-04-28/progress-log.md` (rebased away — entry will re-add)

## Verification
- `npm run build` clean after every commit