### PR TITLE
Bundle N: Manuscripts polish (12 findings)

### DIFF
--- a/src/components/ActiveSubmissionsWidget.tsx
+++ b/src/components/ActiveSubmissionsWidget.tsx
@@ -1,0 +1,177 @@
+/**
+ * ActiveSubmissionsWidget — horizontal scroll of mini-cards representing
+ * the Lab's currently-in-flight submissions (M-12, D25).
+ *
+ * Renders at the top of the Manuscripts List view, above the category
+ * chips and below the NeedsAttentionDashboard. Uses the existing
+ * `/api/submissions/active` endpoint (already returns one row per
+ * active project sorted by upcoming revision due, then submission age).
+ *
+ * Empty state: "No active submissions in the last 30 days." Component
+ * renders nothing while loading so it never causes CLS on the page.
+ */
+
+import { Link } from 'react-router-dom'
+import { Send, Clock, ArrowRight } from 'lucide-react'
+import { useActiveSubmissions } from '../hooks/useApiData'
+import type { ActiveSubmissionRow, SubmissionEventType } from '../lib/api'
+import { PATHS } from '../constants/paths'
+import { formatShortDate } from '../lib/dateUtils'
+
+const EVENT_LABEL: Record<SubmissionEventType, string> = {
+  submitted: 'Submitted',
+  reviews_received: 'Reviews in',
+  revision_due: 'Revision due',
+  resubmitted: 'Resubmitted',
+  accepted: 'Accepted',
+  rejected: 'Rejected',
+  withdrawn: 'Withdrawn',
+}
+
+function MiniCard({ row }: { row: ActiveSubmissionRow }) {
+  const slug = row.project_slug || row.project_id
+  const href = slug ? `${PATHS.project(slug)}?tab=revisions` : PATHS.manuscripts
+  const status = EVENT_LABEL[row.latest_event_type] || row.latest_event_type
+  // Coral if revision is overdue, gold if due soon (<=14d), teal otherwise.
+  const dueIn = row.days_until_revision_due
+  const accent =
+    dueIn !== null && dueIn !== undefined && dueIn < 0
+      ? 'var(--orange)'
+      : dueIn !== null && dueIn !== undefined && dueIn <= 14
+        ? 'var(--gold)'
+        : 'var(--teal)'
+
+  return (
+    <Link
+      to={href}
+      className="active-submission-card"
+      style={{
+        flexShrink: 0,
+        minWidth: '220px',
+        maxWidth: '260px',
+        padding: '10px 12px',
+        borderRadius: 'var(--radius-lg)',
+        border: '1px solid var(--border-subtle)',
+        background: 'var(--surface-1)',
+        textDecoration: 'none',
+        color: 'inherit',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '6px',
+        transition: 'background 0.12s ease-out',
+      }}
+    >
+      <div className="flex items-center gap-1.5" style={{ fontSize: '11px', fontWeight: 500, color: accent, letterSpacing: '0.02em' }}>
+        <span style={{ width: 6, height: 6, borderRadius: 'var(--radius-full)', background: accent }} />
+        {status}
+      </div>
+      <div
+        style={{
+          fontSize: '13px',
+          fontWeight: 500,
+          color: 'var(--ink)',
+          lineHeight: 1.3,
+          overflow: 'hidden',
+          display: '-webkit-box',
+          WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical' as const,
+        }}
+        title={row.project_title || row.project_id}
+      >
+        {row.project_title || 'Untitled project'}
+      </div>
+      <div className="flex items-center gap-2" style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.85 }}>
+        {row.journal && (
+          <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {row.journal}
+          </span>
+        )}
+        {row.revision_due_date && (
+          <span className="ml-auto inline-flex items-center gap-1" style={{ color: accent, fontWeight: 500, flexShrink: 0 }}>
+            <Clock size={10} />
+            {formatShortDate(row.revision_due_date)}
+          </span>
+        )}
+        {!row.revision_due_date && row.days_since_submission !== null && row.days_since_submission !== undefined && (
+          <span className="ml-auto" style={{ color: 'var(--slate)', opacity: 0.75, flexShrink: 0 }}>
+            {row.days_since_submission}d ago
+          </span>
+        )}
+      </div>
+    </Link>
+  )
+}
+
+export default function ActiveSubmissionsWidget() {
+  const { data, isLoading } = useActiveSubmissions()
+  if (isLoading) return null
+  const rows = data ?? []
+
+  return (
+    <div style={{ marginBottom: '1.25rem' }}>
+      <div className="flex items-center gap-2 mb-2">
+        <Send size={14} style={{ color: 'var(--teal)' }} />
+        <h3 style={{ fontSize: '13px', fontWeight: 600, color: 'var(--ink)', margin: 0 }}>
+          Active submissions
+        </h3>
+        <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75 }}>
+          {rows.length === 1 ? '1 paper' : `${rows.length} papers`}
+        </span>
+      </div>
+      {rows.length === 0 ? (
+        <div
+          style={{
+            padding: '10px 14px',
+            borderRadius: 'var(--radius-md)',
+            background: 'var(--surface-2)',
+            fontSize: '12px',
+            color: 'var(--muted)',
+          }}
+        >
+          No active submissions in the last 30 days.
+        </div>
+      ) : (
+        <div
+          className="active-submissions-scroller"
+          style={{
+            display: 'flex',
+            gap: '10px',
+            overflowX: 'auto',
+            paddingBottom: '4px',
+            scrollSnapType: 'x proximity',
+          }}
+        >
+          {rows.map((row) => (
+            <div key={row.id} style={{ scrollSnapAlign: 'start' }}>
+              <MiniCard row={row} />
+            </div>
+          ))}
+          {rows.length >= 4 && (
+            <Link
+              to={PATHS.manuscripts}
+              style={{
+                flexShrink: 0,
+                alignSelf: 'center',
+                padding: '6px 12px',
+                fontSize: '11px',
+                color: 'var(--teal)',
+                textDecoration: 'none',
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: '4px',
+              }}
+            >
+              View all
+              <ArrowRight size={11} />
+            </Link>
+          )}
+        </div>
+      )}
+      <style>{`
+        .active-submission-card:hover {
+          background: var(--surface-2) !important;
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/components/NeedsAttentionDashboard.tsx
+++ b/src/components/NeedsAttentionDashboard.tsx
@@ -47,10 +47,29 @@ export default function NeedsAttentionDashboard({ filter, onFilterChange }: Prop
     try { return localStorage.getItem(LS_COLLAPSED) === 'true' } catch { return false }
   })
   const [expanded, setExpanded] = useState<Set<SubgroupKey>>(() => new Set<SubgroupKey>())
+  // M-10: track whether we've applied the default-expanded urgency rule yet.
+  // First render sets this once data arrives, so users don't have to click
+  // to triage the highest-urgency non-empty subgroup.
+  const [didAutoExpand, setDidAutoExpand] = useState(false)
 
   useEffect(() => {
     try { localStorage.setItem(LS_COLLAPSED, String(sectionCollapsed)) } catch { /* unavailable */ }
   }, [sectionCollapsed])
+
+  // M-10: auto-expand the highest-urgency non-empty subgroup on first load.
+  // Order: revisions-overdue > awaiting-review > stale-drafts.
+  useEffect(() => {
+    if (didAutoExpand || !data) return
+    const { revisions_overdue: ro, awaiting_review: ar, stale_drafts: sd } = data.data
+    let urgent: SubgroupKey | null = null
+    if (ro.length > 0) urgent = 'revisions-overdue'
+    else if (ar.length > 0) urgent = 'awaiting-review'
+    else if (sd.length > 0) urgent = 'stale-drafts'
+    if (urgent) {
+      setExpanded((prev) => new Set<SubgroupKey>([...prev, urgent as SubgroupKey]))
+    }
+    setDidAutoExpand(true)
+  }, [data, didAutoExpand])
 
   if (isLoading || !data) return null
   const { revisions_overdue, awaiting_review, stale_drafts } = data.data

--- a/src/components/NeedsAttentionDashboard.tsx
+++ b/src/components/NeedsAttentionDashboard.tsx
@@ -124,48 +124,78 @@ export default function NeedsAttentionDashboard({ filter, onFilterChange }: Prop
           {SUBGROUPS.filter((g) => counts[g.key] > 0).map((g, idx) => {
             const active = filter === g.key
             const openForReal = isExpanded(g.key)
+            const panelId = `ms-subgroup-${g.key}-rows`
+            // M-09: split chevron-toggles-expand from row-toggles-filter so a
+            // user can read the expanded subgroup AND keep the full table
+            // below the dashboard. Previously one button conflated both.
+            const handleFilterToggle = () => {
+              if (onlyOne) return
+              onFilterChange(active ? null : g.key)
+            }
             return (
               <div key={g.key} style={{ borderBottom: idx < nonEmpty.length - 1 ? '1px solid var(--border-subtle)' : 'none' }}>
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (onlyOne) return
-                    toggleSubgroup(g.key)
-                    onFilterChange(active ? null : g.key)
-                  }}
-                  aria-expanded={openForReal ? "true" : "false"}
-                  className="w-full flex items-center gap-2 text-left"
+                <div
+                  className="w-full flex items-center gap-2"
                   style={{
                     padding: '10px 16px',
-                    border: 'none',
                     background: active ? 'var(--surface-2)' : 'transparent',
-                    cursor: onlyOne ? 'default' : 'pointer',
                     color: 'var(--ink)',
                     fontSize: '13px',
                     fontWeight: 500,
                   }}
                 >
-                  {!onlyOne && (openForReal
-                    ? <ChevronDown size={12} style={{ color: 'var(--slate)', flexShrink: 0 }} />
-                    : <ChevronRight size={12} style={{ color: 'var(--slate)', flexShrink: 0 }} />
+                  {/* Chevron — expand/collapse only. M-17: aria-controls links button to panel. */}
+                  {!onlyOne && (
+                    <button
+                      type="button"
+                      onClick={() => toggleSubgroup(g.key)}
+                      aria-expanded={openForReal ? 'true' : 'false'}
+                      aria-controls={panelId}
+                      aria-label={openForReal ? `Collapse ${g.label}` : `Expand ${g.label}`}
+                      style={{
+                        border: 'none', background: 'transparent', cursor: 'pointer',
+                        padding: '2px', display: 'inline-flex', alignItems: 'center',
+                        flexShrink: 0,
+                      }}
+                    >
+                      {openForReal
+                        ? <ChevronDown size={12} style={{ color: 'var(--slate)' }} />
+                        : <ChevronRight size={12} style={{ color: 'var(--slate)' }} />
+                      }
+                    </button>
                   )}
-                  <span style={{ width: 6, height: 6, borderRadius: 'var(--radius-full)', background: g.dot, flexShrink: 0 }} />
-                  <span>{g.label}</span>
-                  <CountBadge n={counts[g.key]} />
-                  {active && (
-                    <span style={{
-                      marginLeft: 'auto', fontSize: '10px', fontWeight: 500,
-                      color: 'var(--teal)', textTransform: 'uppercase', letterSpacing: '0.04em',
-                    }}>
-                      Filtering
-                    </span>
-                  )}
-                </button>
+                  {/* Row body — filter toggle only. M-09. */}
+                  <button
+                    type="button"
+                    onClick={handleFilterToggle}
+                    aria-pressed={active}
+                    className="flex items-center gap-2 text-left flex-1"
+                    style={{
+                      border: 'none', background: 'transparent',
+                      cursor: onlyOne ? 'default' : 'pointer',
+                      color: 'inherit', fontSize: 'inherit', fontWeight: 'inherit',
+                      padding: 0,
+                    }}
+                  >
+                    <span style={{ width: 6, height: 6, borderRadius: 'var(--radius-full)', background: g.dot, flexShrink: 0 }} />
+                    <span>{g.label}</span>
+                    <CountBadge n={counts[g.key]} />
+                    {active && (
+                      <span style={{
+                        marginLeft: 'auto', fontSize: '10px', fontWeight: 500,
+                        color: 'var(--teal)', textTransform: 'uppercase', letterSpacing: '0.04em',
+                      }}>
+                        Filtering
+                      </span>
+                    )}
+                  </button>
+                </div>
 
                 <AnimatePresence initial={false}>
                   {openForReal && (
                     <motion.div
                       key={`${g.key}-rows`}
+                      id={panelId}
                       initial={{ height: 0 }}
                       animate={{ height: 'auto' }}
                       exit={{ height: 0 }}

--- a/src/components/table/TableContainer.tsx
+++ b/src/components/table/TableContainer.tsx
@@ -7,6 +7,9 @@ interface TableContainerProps {
    * but mixed role="grid" wrappers inside TableContainer caused axe
    * aria-required-children — accepted as a no-op for now (2026-04-18). */
   ariaLabel?: string
+  /** Optional element id. Used by aria-controls handshakes — e.g. the
+   *  Manuscripts category tablist points its tabs at the table id. */
+  id?: string
 }
 
 /**
@@ -20,9 +23,9 @@ interface TableContainerProps {
  * directly on their row wrappers.
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function TableContainer({ children, className, ariaLabel: _ariaLabel }: TableContainerProps) {
+export default function TableContainer({ children, className, ariaLabel: _ariaLabel, id }: TableContainerProps) {
   return (
-    <div className={`table-container${className ? ` ${className}` : ''}`}>
+    <div id={id} className={`table-container${className ? ` ${className}` : ''}`}>
       {children}
     </div>
   )

--- a/src/data/types.ts
+++ b/src/data/types.ts
@@ -103,6 +103,14 @@ export interface Project {
   key_link_2_desc?: string | null
   key_link_3?: string | null
   key_link_3_desc?: string | null
+  // Trophy / publication metadata (M-11). Populated for stage='Published'
+  // projects via the linked publications row. NULL until the project is
+  // shipped + linked. journal_name is the canonical field name; older
+  // payloads may use `journal` or `target_journal` — those are aliases.
+  journal_name?: string | null
+  published_year?: number | null
+  doi?: string | null
+  created_at?: string
 }
 
 export interface Mentee {

--- a/src/hooks/useApiData.ts
+++ b/src/hooks/useApiData.ts
@@ -36,6 +36,7 @@ import {
   fetchDeadlineImpact,
   fetchAllCascades,
   fetchSubmissionEvents,
+  fetchActiveSubmissions,
   fetchExpiringRegulatory,
   fetchUpcomingGrantMilestones,
   fetchConferences,
@@ -1509,6 +1510,17 @@ export function useSubmissionEvents(projectId: string) {
     queryKey: ['submission-events', projectId],
     queryFn: () => fetchSubmissionEvents(projectId).then((r) => r.data),
     enabled: !!projectId,
+    staleTime: 60 * 1000,
+  })
+}
+
+// M-12: lab-wide active submissions list. Drives the Manuscripts page
+// "Active submissions" widget — one row per project whose latest event
+// is not accepted/rejected/withdrawn.
+export function useActiveSubmissions() {
+  return useQuery({
+    queryKey: ['submissions-active'],
+    queryFn: () => fetchActiveSubmissions().then((r) => r.data),
     staleTime: 60 * 1000,
   })
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -826,6 +826,28 @@ export function deleteSubmissionEvent(id: string) {
   })
 }
 
+// Active submissions across all projects — backs the Manuscripts page
+// "Active submissions" widget (M-12). Server returns one row per project
+// whose latest submission event is not accepted/rejected/withdrawn.
+export interface ActiveSubmissionRow {
+  id: string
+  project_id: string
+  latest_event_type: SubmissionEventType
+  latest_event_date: string
+  journal: string | null
+  notes: string | null
+  project_title: string | null
+  project_slug: string | null
+  first_submitted_date: string | null
+  days_since_submission: number | null
+  revision_due_date: string | null
+  days_until_revision_due: number | null
+}
+
+export function fetchActiveSubmissions() {
+  return fetchApi<ActiveSubmissionRow[]>('/api/submissions/active')
+}
+
 // ── Regulatory & Compliance ──────────────────────────────────
 
 interface RegulatoryItemRow {

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -383,7 +383,7 @@ export default function Manuscripts() {
           <TableContainer className={densityClass(density)}>
             {/* Table header — sortable */}
             <div
-              className="hidden sm:grid"
+              className="hidden sm:grid manuscripts-grid-row"
               style={{
                 gridTemplateColumns: 'minmax(200px, 3fr) 90px 100px 140px 80px 68px',
                 padding: 'var(--sp-sm) var(--sp-xl)',
@@ -391,24 +391,25 @@ export default function Manuscripts() {
               }}
             >
               {([
-                { label: 'Title', key: 'title' as const },
-                { label: 'Status', key: 'status' as const },
-                { label: 'Stage', key: 'stage' as const },
-                { label: 'PI', key: 'pi' as const },
-                { label: 'Group', key: 'category' as const },
-                { label: 'Days', key: 'days_in_stage' as const },
+                { label: 'Title', key: 'title' as const, cls: '' },
+                { label: 'Status', key: 'status' as const, cls: '' },
+                { label: 'Stage', key: 'stage' as const, cls: '' },
+                { label: 'PI', key: 'pi' as const, cls: '' },
+                { label: 'Group', key: 'category' as const, cls: 'manuscripts-header-group' },
+                { label: 'Days', key: 'days_in_stage' as const, cls: 'manuscripts-header-days' },
               ]).map((col) => (
-                <ColumnHeader
-                  key={col.key}
-                  label={col.label}
-                  sortKey={col.key}
-                  currentSort={sortKey}
-                  sortAsc={sortAsc}
-                  onSort={(k) => {
-                    if (sortKey === k) setSortAsc(!sortAsc)
-                    else { setSortKey(k as typeof sortKey); setSortAsc(true) }
-                  }}
-                />
+                <div key={col.key} className={col.cls}>
+                  <ColumnHeader
+                    label={col.label}
+                    sortKey={col.key}
+                    currentSort={sortKey}
+                    sortAsc={sortAsc}
+                    onSort={(k) => {
+                      if (sortKey === k) setSortAsc(!sortAsc)
+                      else { setSortKey(k as typeof sortKey); setSortAsc(true) }
+                    }}
+                  />
+                </div>
               ))}
             </div>
 
@@ -452,9 +453,9 @@ export default function Manuscripts() {
                       )}
 
                       <Link to={PATHS.project(project.slug)} className={isFocused ? 'task-row-focused' : ''} style={{ textDecoration: 'none', display: 'block' }}>
-                        {/* Desktop: 6-column grid */}
+                        {/* Desktop: 6-column grid (collapses to 4 cols at 1024-1279px via M-08 CSS) */}
                         <div
-                          className="manuscript-list-row hidden sm:grid"
+                          className="manuscript-list-row manuscripts-grid-row hidden sm:grid"
                           style={{
                             gridTemplateColumns: 'minmax(200px, 3fr) 90px 100px 140px 80px 68px',
                             padding: `var(--row-padding-y, 14px) 24px`,
@@ -576,7 +577,7 @@ export default function Manuscripts() {
                           </div>
 
                           {/* Category — inline editable */}
-                          <div onClick={(e) => e.stopPropagation()}>
+                          <div className="manuscripts-cell-group" onClick={(e) => e.stopPropagation()}>
                             <InlineSelect
                               value={project.category || 'lab'}
                               options={CATEGORY_OPTIONS}
@@ -587,6 +588,7 @@ export default function Manuscripts() {
 
                           {/* Days in stage */}
                           <span
+                            className="manuscripts-cell-days"
                             style={{
                               fontSize: 'var(--text-label)',
                               fontWeight: isStalled ? 600 : 400,
@@ -903,6 +905,21 @@ export default function Manuscripts() {
         }
         .dark .manuscript-list-row:hover {
           background: var(--gold-active) !important;
+        }
+        /* M-08: at 1024-1279px (laptop with sidebar) the 6-col grid squeezes
+           the title. Collapse the Days + Group columns at this range; they
+           re-appear at >=1280px. Below 768px the mobile stacked layout
+           takes over (sm:hidden / sm:grid). */
+        @media (min-width: 768px) and (max-width: 1279px) {
+          .manuscripts-grid-row {
+            grid-template-columns: minmax(200px, 3fr) 90px 100px 140px !important;
+          }
+          .manuscripts-cell-group,
+          .manuscripts-cell-days,
+          .manuscripts-header-group,
+          .manuscripts-header-days {
+            display: none !important;
+          }
         }
       `}</style>
     </div>

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -819,10 +819,11 @@ export default function Manuscripts() {
           return (
             <div className="grid gap-5" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))' }}>
               {published.map((p) => {
-                const journal = (p as any).journal_name || (p as any).target_journal || (p as any).journal || ''
-                const created = (p as any).created_at as string | undefined
-                const year = (p as any).published_year || (p as any).year || (created ? new Date(created).getFullYear() : '')
-                const doi = (p as any).doi
+                // M-11: canonical names live on the Project type. created_at
+                // backfills the year if published_year is missing.
+                const journal = p.journal_name || ''
+                const year = p.published_year || (p.created_at ? new Date(p.created_at).getFullYear() : '')
+                const doi = p.doi
                 return (
                   <div
                     key={p.slug}

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -24,6 +24,7 @@ import EmptyState from '../../components/EmptyState'
 
 import { usePageMeta } from '../../hooks/usePageMeta'
 import { useScrollReveal } from '../../hooks/useScrollReveal'
+import { useLabPrefs } from '../../hooks/useLabPrefs'
 import { PATHS } from '../../constants/paths'
 
 const STAGES = ['Idea', 'Data Collection', 'Analysis', 'Writing', 'Review', 'Revisions', 'Published'] as const
@@ -36,8 +37,6 @@ const PI_OPTIONS = [
   { value: 'nick-ingraham', label: 'Nick Ingraham' },
   { value: 'nate-mesfin', label: 'Nate Mesfin' },
 ] as const
-
-const STALLED_THRESHOLD_DAYS = 30
 
 function daysInStage(project: Project): number {
   const dateStr = project.updated_at || project.lastActivity
@@ -97,6 +96,11 @@ export default function Manuscripts() {
   const { data: projects = [], isLoading } = useProjects()
   const { data: tasks = [] } = useTasks()
   const { data: attentionData } = useManuscriptsAttention()
+  // M-04: stalled threshold now flows from useLabPrefs (same source as
+  // NeedsAttentionDashboard). Previously a hardcoded 30 in this file
+  // produced two parallel staleness models the user couldn't reconcile.
+  const { prefs: labPrefs } = useLabPrefs()
+  const stalledThresholdDays = labPrefs.manuscriptsStaleDays
   const createProject = useCreateProject()
   const queryClient = useQueryClient()
   const { showUndo } = useUndoToast()
@@ -129,7 +133,7 @@ export default function Manuscripts() {
     let filtered = projects.filter((p) => p.status !== 'Published' || p.stage === 'Published')
     if (filterPI) filtered = filtered.filter((p) => p.pi === filterPI)
     if (filterCategory) filtered = filtered.filter((p) => p.category === filterCategory)
-    if (filterStalled) filtered = filtered.filter((p) => p.stage !== 'Published' && daysInStage(p) > STALLED_THRESHOLD_DAYS)
+    if (filterStalled) filtered = filtered.filter((p) => p.stage !== 'Published' && daysInStage(p) > stalledThresholdDays)
     if (attentionFilter && attentionData) {
       const allow = new Set<string>()
       if (attentionFilter === 'revisions-overdue') {
@@ -164,7 +168,7 @@ export default function Manuscripts() {
       if (cmp === 0) cmp = a.title.localeCompare(b.title)
       return sortAsc ? cmp : -cmp
     })
-  }, [projects, filterPI, filterCategory, filterStalled, sortKey, sortAsc, attentionFilter, attentionData])
+  }, [projects, filterPI, filterCategory, filterStalled, sortKey, sortAsc, attentionFilter, attentionData, stalledThresholdDays])
 
   useListKeyboardNav({
     itemCount: view === 'list' ? manuscripts.length : 0,
@@ -201,8 +205,8 @@ export default function Manuscripts() {
   const writingCount = manuscripts.filter((p) => p.stage === 'Writing').length
 
   const stalledCount = useMemo(() =>
-    projects.filter(p => p.stage !== 'Published' && daysInStage(p) > STALLED_THRESHOLD_DAYS).length
-  , [projects])
+    projects.filter(p => p.stage !== 'Published' && daysInStage(p) > stalledThresholdDays).length
+  , [projects, stalledThresholdDays])
 
   // Dynamic page title
   useEffect(() => {
@@ -276,7 +280,7 @@ export default function Manuscripts() {
                     transition: 'all 0.12s ease-out',
                     opacity: filterStalled ? 1 : 0.85,
                   }}
-                  title={`Manuscripts stalled in stage for more than ${STALLED_THRESHOLD_DAYS} days`}
+                  title={`Manuscripts stalled in stage for more than ${stalledThresholdDays} days`}
                 >
                   Stalled
                   {stalledCount > 0 && (
@@ -409,7 +413,7 @@ export default function Manuscripts() {
                   const isFocused = focusedIndex === flatIndex
                   flatIndex++
                   const days = daysInStage(project)
-                  const isStalled = project.stage !== 'Published' && days > STALLED_THRESHOLD_DAYS
+                  const isStalled = project.stage !== 'Published' && days > stalledThresholdDays
 
                   return (
                     <div key={project.slug}>

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -44,14 +44,6 @@ const STAGE_FILL_TOKEN: Record<typeof STAGES[number], string> = {
   Published: 'var(--stage-fill-published)',
 }
 
-// PI options for inline editing. Primary investigators on CCORE manuscripts
-// are the two directors (Nick + Nate). More PIs can be added as they start
-// owning manuscript projects.
-const PI_OPTIONS = [
-  { value: 'nick-ingraham', label: 'Nick Ingraham' },
-  { value: 'nate-mesfin', label: 'Nate Mesfin' },
-] as const
-
 function daysInStage(project: Project): number {
   const dateStr = project.updated_at || project.lastActivity
   if (!dateStr) return 0
@@ -217,6 +209,16 @@ export default function Manuscripts() {
     projects.filter(p => p.stage !== 'Published' && daysInStage(p) > stalledThresholdDays).length
   , [projects, stalledThresholdDays])
 
+  // M-14: derive PI options from data instead of hardcoding nick + nate.
+  // New PIs (mentees taking over a manuscript, visiting faculty) auto-appear.
+  // Names render via getPersonInfo for slug -> display-name resolution.
+  const piOptions = useMemo(() => {
+    const slugs = [...new Set(projects.map((p) => p.pi).filter(Boolean) as string[])]
+    return slugs
+      .map((slug) => ({ value: slug, label: getPersonInfo(slug).name }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  }, [projects])
+
   // M-05: dynamic title flows through usePageMeta so the OG tags + meta
   // description stay in sync. Previously a competing useEffect overwrote
   // document.title, racing usePageMeta and making it dead code.
@@ -268,8 +270,7 @@ export default function Manuscripts() {
                   value={filterPI}
                   options={[
                     { value: '', label: 'All PIs' },
-                    { value: 'nick-ingraham', label: 'Nick Ingraham' },
-                    { value: 'nate-mesfin', label: 'Nate Mesfin' },
+                    ...piOptions,
                   ]}
                   onChange={setFilterPI}
                   alwaysShowChevron
@@ -570,7 +571,7 @@ export default function Manuscripts() {
                             </div>
                             <InlineSelect
                               value={project.pi || 'nick-ingraham'}
-                              options={PI_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+                              options={piOptions}
                               onChange={(val) => handleFieldChange(project.slug, 'pi', val, project.pi)}
                               size="sm"
                             />

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -66,11 +66,6 @@ const CATEGORY_OPTIONS = Object.entries(CATEGORY_LABEL).map(([value, label]) => 
 }))
 
 export default function Manuscripts() {
-  usePageMeta(
-    'Manuscript Pipeline | MN-CCORE',
-    'Track MN-CCORE manuscripts from idea to publication.'
-  )
-
   const [density, setDensity] = useDensity()
   // P3-03: 'trophy' = cover-style grid for Published manuscripts.
   const [view, setView] = useState<'list' | 'pipeline' | 'trophy'>('list')
@@ -208,13 +203,16 @@ export default function Manuscripts() {
     projects.filter(p => p.stage !== 'Published' && daysInStage(p) > stalledThresholdDays).length
   , [projects, stalledThresholdDays])
 
-  // Dynamic page title
-  useEffect(() => {
-    document.title = writingCount > 0
-      ? `Manuscripts (${writingCount} writing) | MN-CCORE`
-      : `Manuscripts (${activeCount}) | MN-CCORE`
-    return () => { document.title = 'MN-CCORE Lab Hub' }
-  }, [writingCount, activeCount])
+  // M-05: dynamic title flows through usePageMeta so the OG tags + meta
+  // description stay in sync. Previously a competing useEffect overwrote
+  // document.title, racing usePageMeta and making it dead code.
+  const pageTitle = writingCount > 0
+    ? `Manuscripts (${writingCount} writing) | MN-CCORE`
+    : `Manuscripts (${activeCount}) | MN-CCORE`
+  usePageMeta(
+    pageTitle,
+    'Track MN-CCORE manuscripts from idea to publication.'
+  )
 
   return (
     <div style={{ minHeight: '100vh' }}>

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -19,6 +19,7 @@ import { displayName } from '../../lib/nameUtils'
 import type { Project } from '../../data/types'
 import PageHeader from '../../components/PageHeader'
 import NeedsAttentionDashboard, { type AttentionFilter } from '../../components/NeedsAttentionDashboard'
+import ActiveSubmissionsWidget from '../../components/ActiveSubmissionsWidget'
 import { ColumnHeader, TableContainer, TableControls } from '../../components/table'
 import EmptyState from '../../components/EmptyState'
 
@@ -332,6 +333,10 @@ export default function Manuscripts() {
         {!isLoading && (
           <NeedsAttentionDashboard filter={attentionFilter} onFilterChange={setAttentionFilter} />
         )}
+
+        {/* M-12 (D25): Active submissions horizontal scroll — papers currently
+            in flight. List view only; pipeline + trophy have their own shape. */}
+        {!isLoading && view === 'list' && <ActiveSubmissionsWidget />}
 
         {/* GH #39: category quick-filter pills. URL-synced so saved views capture state. */}
         <div

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -25,6 +25,7 @@ import EmptyState from '../../components/EmptyState'
 import { usePageMeta } from '../../hooks/usePageMeta'
 import { useScrollReveal } from '../../hooks/useScrollReveal'
 import { useLabPrefs } from '../../hooks/useLabPrefs'
+import { toApiStage } from '../../lib/stageNormalize'
 import { PATHS } from '../../constants/paths'
 
 const STAGES = ['Idea', 'Data Collection', 'Analysis', 'Writing', 'Review', 'Revisions', 'Published'] as const
@@ -478,29 +479,61 @@ export default function Manuscripts() {
                               </span>
                             )}
                             {/* Stage progress dots: past=ink-muted, current=stage-fill (M-06),
-                                future=outlined transparent. */}
-                            <div className="flex items-center gap-0.5 ml-1 flex-shrink-0">
+                                future=outlined transparent. M-07: each dot is a button
+                                that advances the stage to that target with optimistic
+                                update + 5s undo. */}
+                            <div className="flex items-center gap-0.5 ml-1 flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                               {STAGES.map((s, i) => {
                                 const currentIdx = STAGES.indexOf((project.stage as typeof STAGES[number]) || 'Idea')
                                 const isCurrent = i === currentIdx
                                 const isPast = i < currentIdx
                                 return (
-                                  <div
+                                  <button
                                     key={s}
-                                    style={{
-                                      width: 5, height: 5, borderRadius: 'var(--radius-circle)',
-                                      background: isPast
-                                        ? 'var(--ink-muted)'
-                                        : isCurrent
-                                          ? STAGE_FILL_TOKEN[s]
-                                          : 'transparent',
-                                      border: !isCurrent && !isPast ? '1px solid var(--border-subtle)' : 'none',
-                                      opacity: !isCurrent && !isPast ? 0.85 : 1,
-                                      transition: 'background 200ms',
-                                      boxSizing: 'border-box',
+                                    type="button"
+                                    aria-label={`Advance ${project.title} to ${s}`}
+                                    aria-current={isCurrent ? 'step' : undefined}
+                                    onClick={(e) => {
+                                      e.preventDefault()
+                                      e.stopPropagation()
+                                      if (isCurrent) return
+                                      const prevStage = project.stage
+                                      const next = toApiStage(s)
+                                      inlineUpdate.mutate({ slug: project.slug, fields: { stage: next } })
+                                      showUndo(`stage → ${s}`, () =>
+                                        inlineUpdate.mutate({ slug: project.slug, fields: { stage: prevStage } })
+                                      )
                                     }}
-                                    title={s}
-                                  />
+                                    style={{
+                                      width: 11, height: 11,
+                                      padding: 3,
+                                      display: 'inline-flex',
+                                      alignItems: 'center',
+                                      justifyContent: 'center',
+                                      borderRadius: 'var(--radius-circle)',
+                                      background: 'transparent',
+                                      border: 'none',
+                                      cursor: isCurrent ? 'default' : 'pointer',
+                                    }}
+                                    title={isCurrent ? `${s} (current stage)` : `Advance to ${s}`}
+                                  >
+                                    <span
+                                      aria-hidden="true"
+                                      style={{
+                                        width: 5, height: 5, borderRadius: 'var(--radius-circle)',
+                                        background: isPast
+                                          ? 'var(--ink-muted)'
+                                          : isCurrent
+                                            ? STAGE_FILL_TOKEN[s]
+                                            : 'transparent',
+                                        border: !isCurrent && !isPast ? '1px solid var(--border-subtle)' : 'none',
+                                        opacity: !isCurrent && !isPast ? 0.85 : 1,
+                                        transition: 'background 200ms',
+                                        boxSizing: 'border-box',
+                                        display: 'block',
+                                      }}
+                                    />
+                                  </button>
                                 )
                               })}
                             </div>

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -2,6 +2,18 @@ import { useState, useMemo, useEffect } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import { FileText, Plus, List, GitBranch, BookOpen, ExternalLink } from 'lucide-react'
+import {
+  DndContext,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  useDraggable,
+  useDroppable,
+  DragOverlay,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core'
 import { useDensity, densityClass } from '../../components/DensityToggle'
 import { TableSkeleton } from '../../components/LoadingSkeleton'
 import Avatar from '../../components/Avatar'
@@ -724,90 +736,18 @@ export default function Manuscripts() {
           </TableContainer>
         )}
 
-        {/* ─── PIPELINE VIEW ─── */}
+        {/* ─── PIPELINE VIEW ─── M-13: drag-and-drop between stages */}
         {!isLoading && view === 'pipeline' && (
-          <div
-            style={{
-              display: 'grid',
-              gridTemplateColumns: `repeat(${STAGES.length}, minmax(180px, 1fr))`,
-              gap: '20px',
-              overflowX: 'auto',
-              paddingBottom: '1rem',
-            }}
-          >
-            {STAGES.map((stage) => {
-              const stageProjects = byStage[stage] || []
-              return (
-                <div
-                  key={stage}
-                  style={{
-                    background: 'var(--ice)',
-                    borderRadius: 'var(--radius-xl)',
-                    borderTop: '2px solid var(--teal)',
-                    padding: 'var(--sp-lg)',
-                    minHeight: '200px',
-                  }}
-                >
-                  <div className="flex items-center justify-between" style={{ marginBottom: '12px' }}>
-                    <h3 style={{ fontWeight: 500, fontSize: '13px', color: 'var(--ink)', margin: 0 }}>
-                      {stage}
-                    </h3>
-                    <span style={{ fontSize: '12px', color: 'var(--slate)', opacity: 0.75, fontWeight: 500 }}>
-                      {stageProjects.length}
-                    </span>
-                  </div>
-
-                  <div className="flex flex-col" style={{ gap: '10px' }}>
-                    <AnimatePresence mode="popLayout">
-                      {stageProjects.map((p) => {
-                        const pi = getPersonInfo(p.pi)
-                        return (
-                          <Link key={p.slug} to={PATHS.project(p.slug)} style={{ textDecoration: 'none', display: 'block' }}>
-                            <motion.div
-                              layout
-                              initial={{ opacity: 0, y: 8 }}
-                              animate={{ opacity: 1, y: 0 }}
-                              exit={{ opacity: 0, y: -8 }}
-                              className="project-card"
-                              style={{
-                                background: 'var(--cream)',
-                                borderRadius: 'var(--radius-lg)',
-                                padding: '14px',
-                                boxShadow: 'var(--shadow-card)',
-                                transition: 'box-shadow 0.25s ease',
-                              }}
-                            >
-                              <div className="flex items-start gap-2">
-                                <CategoryIcon category={p.category} size={12} style={{ flexShrink: 0, marginTop: '2px' }} />
-                                <p style={{ fontSize: '13px', fontWeight: 600, color: 'var(--ink)', lineHeight: 1.4, margin: 0 }}>
-                                  {p.title}
-                                </p>
-                              </div>
-                              <div className="flex items-center gap-1.5" style={{ marginTop: '6px', marginLeft: '14px' }}>
-                                <div style={{ width: 16, height: 16, flexShrink: 0 }}>
-                                  <Avatar name={pi.name} initials={pi.initials} photoUrl={pi.photoUrl} size="2xs" variant="ice" />
-                                </div>
-                                <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75 }}>
-                                  {p.pi ? displayName(p.pi, 'short') : pi.name}
-                                </span>
-                              </div>
-                            </motion.div>
-                          </Link>
-                        )
-                      })}
-                    </AnimatePresence>
-                    {stageProjects.length === 0 && (
-                      <div style={{ padding: 'var(--sp-xl) var(--sp-sm)', textAlign: 'center' }}>
-                        <span style={{ fontSize: '12px', color: 'var(--slate)', opacity: 0.75 }}>
-                          No projects
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                </div>
+          <PipelineBoard
+            byStage={byStage}
+            onStageChange={(slug, prevStage, nextStage) => {
+              const apiStage = toApiStage(nextStage)
+              inlineUpdate.mutate({ slug, fields: { stage: apiStage } })
+              showUndo(`stage → ${nextStage}`, () =>
+                inlineUpdate.mutate({ slug, fields: { stage: prevStage } })
               )
-            })}
-          </div>
+            }}
+          />
         )}
 
         {/* ─── TROPHY VIEW (P3-03) ─── cover-style cards for Published manuscripts */}
@@ -931,5 +871,194 @@ export default function Manuscripts() {
         }
       `}</style>
     </div>
+  )
+}
+
+// ───────────────────────────────────────────────────────────────────────
+// M-13: Pipeline drag-and-drop. PipelineBoard wraps the kanban in
+// DndContext + per-column droppable + per-card draggable. Drag a card
+// onto a different stage column → fires onStageChange. Optimistic update
+// + 5s undo handled in parent.
+// ───────────────────────────────────────────────────────────────────────
+
+type StageKey = typeof STAGES[number]
+
+function PipelineCard({ project, dragging }: { project: Project; dragging?: boolean }) {
+  const pi = getPersonInfo(project.pi)
+  return (
+    <div
+      className="project-card"
+      style={{
+        background: 'var(--cream)',
+        borderRadius: 'var(--radius-lg)',
+        padding: '14px',
+        boxShadow: dragging ? 'var(--shadow-elevated)' : 'var(--shadow-card)',
+        opacity: dragging ? 0.92 : 1,
+        cursor: dragging ? 'grabbing' : 'grab',
+        transition: 'box-shadow 0.15s ease',
+        userSelect: 'none',
+      }}
+    >
+      <div className="flex items-start gap-2">
+        <CategoryIcon category={project.category} size={12} style={{ flexShrink: 0, marginTop: '2px' }} />
+        <p style={{ fontSize: '13px', fontWeight: 600, color: 'var(--ink)', lineHeight: 1.4, margin: 0 }}>
+          {project.title}
+        </p>
+      </div>
+      <div className="flex items-center gap-1.5" style={{ marginTop: '6px', marginLeft: '14px' }}>
+        <div style={{ width: 16, height: 16, flexShrink: 0 }}>
+          <Avatar name={pi.name} initials={pi.initials} photoUrl={pi.photoUrl} size="2xs" variant="ice" />
+        </div>
+        <span style={{ fontSize: '11px', color: 'var(--slate)', opacity: 0.75 }}>
+          {project.pi ? displayName(project.pi, 'short') : pi.name}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function DraggableCard({ project, isAnyDragging }: { project: Project; isAnyDragging: boolean }) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
+    id: project.slug,
+    data: { stage: project.stage },
+  })
+  return (
+    <div ref={setNodeRef} {...attributes} {...listeners}>
+      {/* Click navigates only when no drag in progress. */}
+      <Link
+        to={PATHS.project(project.slug)}
+        onClick={(e) => { if (isAnyDragging) e.preventDefault() }}
+        style={{ textDecoration: 'none', display: 'block' }}
+        draggable={false}
+      >
+        <motion.div
+          layout
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: isDragging ? 0 : 1, y: 0 }}
+          exit={{ opacity: 0, y: -8 }}
+        >
+          <PipelineCard project={project} />
+        </motion.div>
+      </Link>
+    </div>
+  )
+}
+
+function DroppableColumn({
+  stage,
+  children,
+}: {
+  stage: StageKey
+  children: React.ReactNode
+}) {
+  const { setNodeRef, isOver } = useDroppable({
+    id: `pipeline-col-${stage}`,
+    data: { stage },
+  })
+  return (
+    <div
+      ref={setNodeRef}
+      style={{
+        background: isOver ? 'var(--teal-hover)' : 'var(--ice)',
+        borderRadius: 'var(--radius-xl)',
+        borderTop: isOver ? '2px solid var(--gold)' : '2px solid var(--teal)',
+        padding: 'var(--sp-lg)',
+        minHeight: '200px',
+        transition: 'background 0.12s ease-out, border-color 0.12s ease-out',
+      }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function PipelineBoard({
+  byStage,
+  onStageChange,
+}: {
+  byStage: Record<string, Project[]>
+  onStageChange: (slug: string, prevStage: string, nextStage: StageKey) => void
+}) {
+  const [activeId, setActiveId] = useState<string | null>(null)
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+    useSensor(KeyboardSensor),
+  )
+
+  const allProjects = useMemo(() => {
+    const out: Project[] = []
+    for (const s of STAGES) for (const p of byStage[s] || []) out.push(p)
+    return out
+  }, [byStage])
+
+  const activeProject = activeId ? allProjects.find((p) => p.slug === activeId) ?? null : null
+
+  function handleDragStart(e: DragStartEvent) {
+    setActiveId(String(e.active.id))
+  }
+
+  function handleDragEnd(e: DragEndEvent) {
+    setActiveId(null)
+    const { active, over } = e
+    if (!over) return
+    const draggedSlug = String(active.id)
+    const sourceStage = String((active.data.current as { stage?: string } | undefined)?.stage ?? '')
+    const targetStage = (over.data.current as { stage?: StageKey } | undefined)?.stage
+    if (!targetStage || sourceStage === targetStage) return
+    onStageChange(draggedSlug, sourceStage, targetStage)
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      onDragStart={handleDragStart}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveId(null)}
+    >
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: `repeat(${STAGES.length}, minmax(180px, 1fr))`,
+          gap: '20px',
+          overflowX: 'auto',
+          paddingBottom: '1rem',
+        }}
+      >
+        {STAGES.map((stage) => {
+          const stageProjects = byStage[stage] || []
+          return (
+            <DroppableColumn key={stage} stage={stage}>
+              <div className="flex items-center justify-between" style={{ marginBottom: '12px' }}>
+                <h3 style={{ fontWeight: 500, fontSize: '13px', color: 'var(--ink)', margin: 0 }}>
+                  {stage}
+                </h3>
+                <span style={{ fontSize: '12px', color: 'var(--slate)', opacity: 0.75, fontWeight: 500 }}>
+                  {stageProjects.length}
+                </span>
+              </div>
+
+              <div className="flex flex-col" style={{ gap: '10px' }}>
+                <AnimatePresence mode="popLayout">
+                  {stageProjects.map((p) => (
+                    <DraggableCard key={p.slug} project={p} isAnyDragging={activeId !== null} />
+                  ))}
+                </AnimatePresence>
+                {stageProjects.length === 0 && (
+                  <div style={{ padding: 'var(--sp-xl) var(--sp-sm)', textAlign: 'center' }}>
+                    <span style={{ fontSize: '12px', color: 'var(--slate)', opacity: 0.75 }}>
+                      Drop here
+                    </span>
+                  </div>
+                )}
+              </div>
+            </DroppableColumn>
+          )
+        })}
+      </div>
+
+      <DragOverlay>
+        {activeProject ? <PipelineCard project={activeProject} dragging /> : null}
+      </DragOverlay>
+    </DndContext>
   )
 }

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -30,6 +30,19 @@ import { PATHS } from '../../constants/paths'
 const STAGES = ['Idea', 'Data Collection', 'Analysis', 'Writing', 'Review', 'Revisions', 'Published'] as const
 const STAGE_ORDER: Record<string, number> = Object.fromEntries(STAGES.map((s, i) => [s, i]))
 
+// M-06: stage-progress dots use --stage-fill-* tokens (per Rule 41) so the
+// current-stage dot stays AA-stable across both themes. --teal flips to a
+// light dark-mode variant where it would fail contrast against row-hover bg.
+const STAGE_FILL_TOKEN: Record<typeof STAGES[number], string> = {
+  Idea: 'var(--stage-fill-idea)',
+  'Data Collection': 'var(--stage-fill-data-collection)',
+  Analysis: 'var(--stage-fill-analysis)',
+  Writing: 'var(--stage-fill-writing)',
+  Review: 'var(--stage-fill-review)',
+  Revisions: 'var(--stage-fill-revisions)',
+  Published: 'var(--stage-fill-published)',
+}
+
 // PI options for inline editing. Primary investigators on CCORE manuscripts
 // are the two directors (Nick + Nate). More PIs can be added as they start
 // owning manuscript projects.
@@ -464,22 +477,25 @@ export default function Manuscripts() {
                                 {tc}
                               </span>
                             )}
-                            {/* Stage progress dots: completed=gray filled, current=teal, pending=faint outlined */}
+                            {/* Stage progress dots: past=ink-muted, current=stage-fill (M-06),
+                                future=outlined transparent. */}
                             <div className="flex items-center gap-0.5 ml-1 flex-shrink-0">
                               {STAGES.map((s, i) => {
                                 const currentIdx = STAGES.indexOf((project.stage as typeof STAGES[number]) || 'Idea')
+                                const isCurrent = i === currentIdx
+                                const isPast = i < currentIdx
                                 return (
                                   <div
                                     key={s}
                                     style={{
                                       width: 5, height: 5, borderRadius: 'var(--radius-circle)',
-                                      background: i < currentIdx
+                                      background: isPast
                                         ? 'var(--ink-muted)'
-                                        : i === currentIdx
-                                          ? 'var(--teal)'
+                                        : isCurrent
+                                          ? STAGE_FILL_TOKEN[s]
                                           : 'transparent',
-                                      border: i > currentIdx ? '1px solid var(--border-subtle)' : 'none',
-                                      opacity: i > currentIdx ? 0.85 : 1,
+                                      border: !isCurrent && !isPast ? '1px solid var(--border-subtle)' : 'none',
+                                      opacity: !isCurrent && !isPast ? 0.85 : 1,
                                       transition: 'background 200ms',
                                       boxSizing: 'border-box',
                                     }}

--- a/src/pages/portal/Manuscripts.tsx
+++ b/src/pages/portal/Manuscripts.tsx
@@ -350,6 +350,7 @@ export default function Manuscripts() {
                 key={opt.value || 'all'}
                 role="tab"
                 aria-selected={active}
+                aria-controls="manuscripts-table"
                 onClick={() => setFilterCategory(opt.value)}
                 style={{
                   display: 'inline-flex',
@@ -381,7 +382,7 @@ export default function Manuscripts() {
 
         {/* ─── LIST VIEW ─── */}
         {!isLoading && view === 'list' && (
-          <TableContainer className={densityClass(density)}>
+          <TableContainer id="manuscripts-table" className={densityClass(density)}>
             {/* Table header — sortable */}
             <div
               className="hidden sm:grid manuscripts-grid-row"


### PR DESCRIPTION
Wave 4. Manuscripts feature pass — Active Submissions, Pipeline DnD, click-to-advance dots, NeedsAttention split, schema-aware Project type. Build clean.

## Closes (12/12)

- **M-04** — `STALLED_THRESHOLD_DAYS=30` constant replaced with `useLabPrefs().manuscriptsStaleDays` (single source of truth)
- **M-05** — Drop racing `useEffect`; route dynamic count through `usePageMeta(pageTitle)`
- **M-06** — Stage dots use `--stage-fill-*` tokens (Rule 41) instead of `--teal`
- **M-07** — Clickable stage dots advance stage with optimistic + 5s undo via `toApiStage`
- **M-08** — New `@media (768-1279px)` breakpoint hides Days + Group columns
- **M-09 + M-17** — Split chevron-expand from row-filter; chevron has `aria-expanded` + `aria-controls`; panel has matching id
- **M-10** — Auto-expand highest-urgency non-empty subgroup on first render
- **M-11** — Added `journal_name` / `published_year` / `doi` / `created_at` to `Project` type; dropped 4 `as any` casts
- **M-12** (D25) — `<ActiveSubmissionsWidget>` reuses existing `/api/submissions/active` endpoint; new `useActiveSubmissions` hook
- **M-13** (D26) — Pipeline drag-and-drop via `@dnd-kit/core`; PointerSensor (6px) + KeyboardSensor; optimistic + undo
- **M-14** (D27) — Derive PI options from `[...new Set(projects.map(p => p.pi))]`; removed hardcoded `PI_OPTIONS`
- **M-18** — Category tabs `aria-controls='manuscripts-table'`; extended `TableContainer` with optional `id` prop

## Pattern surprises

- **`/api/submissions/active` already existed** at `api/routes/submissions.ts:127-180` — no new endpoint needed for M-12. Reused existing infrastructure.
- **`@dnd-kit/core@6.3.1` already in lockfile** — no new dep for M-13.
- **Project type was missing `journal_name`/`published_year`/`doi`/`created_at`** — added optional. Fields aren't yet populated by API; auto-link to `publications` on `stage='Published'` is separate follow-up.

## Out-of-scope follow-ups (noted in progress log)

- M-02 (stale-drafts join by title — needs backend change)
- M-03 (`stage_entered_at` schema bump — D7 cross-repo)
- Auto-link Published projects to publications rows

## Files

- `src/pages/portal/Manuscripts.tsx` (10 findings)
- `src/components/NeedsAttentionDashboard.tsx` (M-09, M-10, M-17)
- `src/components/ActiveSubmissionsWidget.tsx` (new — M-12)
- `src/components/table/TableContainer.tsx` (M-18)
- `src/data/types.ts` (M-11)
- `src/lib/api.ts` (M-12)
- `src/hooks/useApiData.ts` (M-12)
- `audit/2026-04-28/progress-log.md` (rebased away — entry will re-add)

## Verification
- `npm run build` clean (TypeScript + Vite) at every commit