### PR TITLE
doc(schema): dedupe stacked anti-pattern markers in v51/v52/v53

### DIFF
--- a/api/schema-v51-seq-cursor.sql
+++ b/api/schema-v51-seq-cursor.sql
@@ -1,4 +1,8 @@
 -- v51 — server-assigned monotonic seq cursor for projects + tasks
+-- anti-pattern-allowed-file: historical migration. The UPDATE OF column-list
+--   pattern (R4) and MAX(seq) WHERE id != NEW.id (R3) are documented bugs
+--   superseded by v52 (drops UPDATE OF) and v53 (drops self-exclusion).
+--   File is already applied to prod D1 and immutable.
 --
 -- Per Context/Topics/research-bidirectional-sync-2026-04-28.md (Peripheral
 -- Brain repo) and the 2026-04-28 home<->work brainstorm, replace wall-clock

--- a/api/schema-v52-seq-trigger-fix.sql
+++ b/api/schema-v52-seq-trigger-fix.sql
@@ -1,4 +1,7 @@
 -- v52 — fix v51 trigger UPDATE OF column gap
+-- anti-pattern-allowed-file: historical migration. The MAX(seq) WHERE id != NEW.id
+--   (R3) pattern is the v52 self-exclusion bug, fixed in v53. Already applied
+--   to prod D1 and immutable.
 --
 -- v51 listed specific columns in UPDATE OF for the seq-bump triggers.
 -- That list was incomplete:

--- a/api/schema-v53-seq-trigger-include-self.sql
+++ b/api/schema-v53-seq-trigger-include-self.sql
@@ -1,4 +1,8 @@
 -- v53 — fix v52 seq trigger: include self in MAX(seq) computation
+-- anti-pattern-allowed-file: this file's body comment quotes the v52 buggy
+--   line `MAX(seq) WHERE id != NEW.id` to document what's being fixed.
+--   The actual trigger DDL below uses `MAX(seq)` with no `WHERE id != NEW.id`.
+--   File is the FIX.
 --
 -- v52 fixed the column-coverage gap by removing UPDATE OF (so triggers
 -- fire on every column change). But the trigger body still excludes the


### PR DESCRIPTION
Follow-up to PR #66. Both #66 and an earlier upstream commit (d4de0726) added `anti-pattern-allowed-file` markers to the same files, producing stacked redundant comments after the merge (v52 + v53) plus a conflict in v51. Keep one marker per file with the more detailed wording.

Pure doc change, no functional impact.