### PR TITLE
fix(layout): unify portal page-width contract + targeted consistency fixes

### DIFF
--- a/src/components/PageContainer.tsx
+++ b/src/components/PageContainer.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+interface PageContainerProps {
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * Shared page-root wrapper for portal pages.
+ *
+ * Owns the single content-width contract: max-width 1440px, centered, with
+ * responsive horizontal padding (the `.content-container` rules in index.css).
+ * The portal `<main>` (PortalLayout) already supplies vertical padding, so
+ * pages should NOT add their own `minHeight`/`paddingBottom` on top of this.
+ *
+ * Intentionally NOT used by full-bleed operating surfaces (Today, MyTasks,
+ * Calendar, Personal), which manage their own edge-to-edge layout.
+ */
+export default function PageContainer({ children, className }: PageContainerProps) {
+  return (
+    <div className={`content-container${className ? ` ${className}` : ''}`}>
+      {children}
+    </div>
+  )
+}

--- a/src/pages/portal/ActivityPage.tsx
+++ b/src/pages/portal/ActivityPage.tsx
@@ -11,6 +11,7 @@ import { useListKeyboardNav } from '../../hooks/useListKeyboardNav'
 import { getPersonInfo, getMemberBySlug, directors } from '../../data/team'
 import { formatRelativeTime, formatMediumDate, localDateKey } from '../../lib/dateUtils'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyState from '../../components/EmptyState'
 import InlineSelect from '../../components/InlineSelect'
 import { staggerContainer, staggerItem } from '../../lib/animations'
@@ -102,7 +103,7 @@ export default function ActivityPage() {
   useEffect(() => { setFocusedIndex(-1) }, [filterTypes, filterPerson])
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<ActivityIcon size={20} />}
         title="Activity"
@@ -259,7 +260,7 @@ export default function ActivityPage() {
           />
         )}
       </div>
-    </div>
+    </PageContainer>
   )
 }
 

--- a/src/pages/portal/AnalyticsPage.tsx
+++ b/src/pages/portal/AnalyticsPage.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion'
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Cell } from 'recharts'
 import { CheckCircle2, Plus, AlertTriangle, TrendingUp, Users, FolderKanban, Lightbulb, FileText, ChevronLeft, ChevronRight, Calendar, Circle, BarChart3, Download, Copy } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import MetricCard from '../../components/MetricCard'
 import { CardSkeleton } from '../../components/LoadingSkeleton'
 import QueryState from '../../components/QueryState'
@@ -324,7 +325,7 @@ export default function AnalyticsPage() {
       : `${projects.length} projects, ${pendingTasks} active tasks`
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<BarChart3 size={20} />}
         title="Lab Analytics"
@@ -778,6 +779,6 @@ export default function AnalyticsPage() {
       )}
 
       </QueryState>
-    </div>
+    </PageContainer>
   )
 }

--- a/src/pages/portal/AskTheLab.tsx
+++ b/src/pages/portal/AskTheLab.tsx
@@ -8,6 +8,7 @@ import SmartCompose from '../../components/SmartCompose'
 import { motion, AnimatePresence } from 'framer-motion'
 import { CardSkeleton } from '../../components/LoadingSkeleton'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyStateComponent from '../../components/EmptyState'
 import ToggleButton from '../../components/ToggleButton'
 import Avatar from '../../components/Avatar'
@@ -65,7 +66,7 @@ export default function AskTheLab() {
   const openCount = questions.filter((q) => q.status === 'open').length
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<HelpCircle size={20} />}
         title="Ask the Lab"
@@ -135,7 +136,7 @@ export default function AskTheLab() {
 
       {/* Create modal */}
       <CreateQuestionModal open={showCreate} onClose={() => setShowCreate(false)} />
-    </div>
+    </PageContainer>
   )
 }
 

--- a/src/pages/portal/CalendarPage.tsx
+++ b/src/pages/portal/CalendarPage.tsx
@@ -327,7 +327,7 @@ function MonthView({ currentDate, events, denseWeek = false }: { currentDate: Da
             {week.map((cell, ci) => {
               if (cell.kind === 'fill') {
                 return (
-                  <div key={`fill-${wi}-${ci}`} className="min-h-[80px] border-b border-r" style={{ borderColor: 'var(--border-subtle)', backgroundColor: 'var(--hover-subtle)' }} />
+                  <div key={`fill-${wi}-${ci}`} className="md:min-h-[80px] border-b border-r" style={{ borderColor: 'var(--border-subtle)', backgroundColor: 'var(--hover-subtle)' }} />
                 )
               }
               const dateStr = cell.dateStr
@@ -348,7 +348,7 @@ function DayCellRender({ dateStr, today, dayEvents }: { dateStr: string; today: 
   const dayNum = parseInt(dateStr.split('-')[2])
   const isToday = dateStr === today
   return (
-    <div className="min-h-[80px] p-1.5 border-b border-r relative" style={{ borderColor: 'var(--border-subtle)', backgroundColor: isToday ? 'var(--teal-hover)' : 'var(--cream)', boxShadow: isToday ? 'inset 0 0 0 2px rgba(45,138,138,0.2)' : 'none' }}>
+    <div className="md:min-h-[80px] p-1.5 border-b border-r relative" style={{ borderColor: 'var(--border-subtle)', backgroundColor: isToday ? 'var(--teal-hover)' : 'var(--cream)', boxShadow: isToday ? 'inset 0 0 0 2px rgba(45,138,138,0.2)' : 'none' }}>
       <span className={`inline-flex items-center justify-center text-xs font-medium ${isToday ? 'rounded-full' : ''}`} style={{ width: isToday ? 24 : 'auto', height: isToday ? 24 : 'auto', color: isToday ? 'var(--ink-bright, #fff)' : 'var(--ink)', backgroundColor: isToday ? 'var(--teal-solid)' : 'transparent' }}>
         {dayNum}
       </span>
@@ -406,7 +406,7 @@ function WeekView({ weekStart, events }: { weekStart: Date; events: CalendarEven
         const dayEvents = eventsByDate.get(dateStr) || []
 
         return (
-          <div key={dateStr} className="rounded-lg border min-h-[300px]" style={{ borderColor: isToday ? 'var(--teal)' : 'var(--border-subtle)', backgroundColor: isToday ? 'var(--teal-hover)' : 'var(--cream)' }}>
+          <div key={dateStr} className="rounded-lg border md:min-h-[300px]" style={{ borderColor: isToday ? 'var(--teal)' : 'var(--border-subtle)', backgroundColor: isToday ? 'var(--teal-hover)' : 'var(--cream)' }}>
             {/* Day header */}
             <div className="px-2 py-2 border-b text-center" style={{ borderColor: 'var(--border-subtle)' }}>
               <div className="text-[10px] uppercase tracking-wider" style={{ color: 'var(--slate)', opacity: 'var(--ink-label)' }}>{dayNames[i]}</div>

--- a/src/pages/portal/DeadlineCascadePage.tsx
+++ b/src/pages/portal/DeadlineCascadePage.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { GitBranch, Filter, RotateCcw } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import { TableSkeleton } from '../../components/LoadingSkeleton'
 import DeadlineCascade from '../../components/DeadlineCascade'
 import ToggleButton from '../../components/ToggleButton'
@@ -71,7 +72,7 @@ export default function DeadlineCascadePage() {
   const chainsWithDeps = projectGroups.filter(g => g.graph.dependencies.length > 0).length
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<GitBranch size={20} />}
         // P2-R2-07: page name was "Deadline Cascade" but until dependency
@@ -189,6 +190,6 @@ export default function DeadlineCascadePage() {
           </motion.div>
         )}
       </div>
-    </div>
+    </PageContainer>
   )
 }

--- a/src/pages/portal/MeetingNotesPage.tsx
+++ b/src/pages/portal/MeetingNotesPage.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import { staggerContainer, staggerItem } from '../../lib/animations'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyState from '../../components/EmptyState'
 import MetricCard from '../../components/MetricCard'
 import InlineSelect from '../../components/InlineSelect'
@@ -115,7 +116,7 @@ export default function MeetingNotesPage() {
   if (isLoading) return <TableSkeleton rows={5} cols={3} />
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<FileText size={20} />}
         title="Meeting Transcripts"
@@ -223,7 +224,7 @@ export default function MeetingNotesPage() {
 
       {/* Upload/Paste Modal */}
       {showCreate && <TranscriptModal onClose={() => setShowCreate(false)} meetings={meetings} />}
-    </div>
+    </PageContainer>
   )
 }
 

--- a/src/pages/portal/MenteeMilestonesPage.tsx
+++ b/src/pages/portal/MenteeMilestonesPage.tsx
@@ -5,6 +5,7 @@ import { GraduationCap, Plus, ChevronDown, ChevronRight, X, Check, AlertTriangle
 import DensityToggle, { useDensity, densityClass } from '../../components/DensityToggle'
 import { TableSkeleton } from '../../components/LoadingSkeleton'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyState from '../../components/EmptyState'
 import Avatar from '../../components/Avatar'
 import InlineSelect from '../../components/InlineSelect'
@@ -181,7 +182,7 @@ export default function MenteeMilestonesPage() {
   })
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<GraduationCap size={20} />}
         title="Mentee Milestones"
@@ -456,7 +457,7 @@ export default function MenteeMilestonesPage() {
       <AnimatePresence>
         {showAddModal && <AddMilestoneModal menteeSlugs={menteeSlugsDerived} onClose={() => setShowAddModal(false)} />}
       </AnimatePresence>
-    </div>
+    </PageContainer>
   )
 }
 

--- a/src/pages/portal/NarrativesPage.tsx
+++ b/src/pages/portal/NarrativesPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { BookOpen, GitBranch, FileText, Search } from 'lucide-react'
 import { Link } from 'react-router-dom'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyState from '../../components/EmptyState'
 import { TableSkeleton } from '../../components/LoadingSkeleton'
 import { useNarratives } from '../../hooks/useApiData'
@@ -49,7 +50,7 @@ export default function NarrativesPage() {
   useListKeyboardNav({ itemCount: filteredNarratives.length, focusedIndex, setFocusedIndex })
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<BookOpen size={20} />}
         title="Research Narratives"
@@ -191,6 +192,6 @@ export default function NarrativesPage() {
           ))}
         </div>
       )}
-    </div>
+    </PageContainer>
   )
 }

--- a/src/pages/portal/PIAnalytics.tsx
+++ b/src/pages/portal/PIAnalytics.tsx
@@ -32,6 +32,7 @@ import {
   Copy,
 } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import MetricCard from '../../components/MetricCard'
 import { CardSkeleton } from '../../components/LoadingSkeleton'
 import QueryState from '../../components/QueryState'
@@ -344,7 +345,7 @@ export default function PIAnalytics() {
   }
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<Shield size={20} />}
         title="PI Dashboard"
@@ -903,6 +904,6 @@ export default function PIAnalytics() {
       </div>
 
       </QueryState>
-    </div>
+    </PageContainer>
   )
 }

--- a/src/pages/portal/ProfilePage.tsx
+++ b/src/pages/portal/ProfilePage.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect } from 'react'
 import { Navigate, Link } from 'react-router-dom'
+import { PATHS } from '../../constants/paths'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { User, Save, Calendar as CalendarIcon, Settings as SettingsIcon, ExternalLink } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
@@ -113,7 +114,7 @@ export default function ProfilePage() {
   })
 
   if (authLoading) return <TextSkeleton lines={6} />
-  if (!isAuthenticated) return <Navigate to="/portal/dashboard" replace />
+  if (!isAuthenticated) return <Navigate to={PATHS.dashboard} replace />
   if (!slug) {
     return (
       <div className="content-container">
@@ -168,7 +169,7 @@ export default function ProfilePage() {
               </span>
             ) : null}
             <Link
-              to={`/portal/team/${slug}`}
+              to={PATHS.teamMember(slug)}
               className="inline-flex items-center gap-1 text-[11px]"
               style={{ color: 'var(--teal)' }}
             >
@@ -224,7 +225,7 @@ export default function ProfilePage() {
       {/* Settings link */}
       <section>
         <Link
-          to="/portal/settings"
+          to={PATHS.settings}
           className="inline-flex items-center gap-2 text-xs"
           style={{ color: 'var(--teal)' }}
         >

--- a/src/pages/portal/SearchPage.tsx
+++ b/src/pages/portal/SearchPage.tsx
@@ -9,6 +9,7 @@ import {
   AlertTriangle, Calendar,
 } from 'lucide-react'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyState from '../../components/EmptyState'
 import { TextSkeleton } from '../../components/LoadingSkeleton'
 import { formatBrandName } from '../../components/BrandName'
@@ -468,7 +469,7 @@ export default function SearchPage() {
   }
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader icon={<Search size={20} />} title="Search" subtitle="Find anything across the lab" />
 
       {/* S-04: sticky search input + chips so input stays visible during scroll. */}
@@ -800,7 +801,7 @@ export default function SearchPage() {
 
       {/* Suppress lint use of submittedQueries — kept for future analytics surfaces. */}
       <span style={{ display: 'none' }}>{submittedQueries.size}</span>
-    </div>
+    </PageContainer>
   )
 }
 

--- a/src/pages/portal/SessionHistory.tsx
+++ b/src/pages/portal/SessionHistory.tsx
@@ -6,6 +6,7 @@ import type { PBSessionRow } from '../../hooks/useApiData'
 import { useListKeyboardNav } from '../../hooks/useListKeyboardNav'
 import { formatMediumDate, localDateKey } from '../../lib/dateUtils'
 import PageHeader from '../../components/PageHeader'
+import PageContainer from '../../components/PageContainer'
 import EmptyState from '../../components/EmptyState'
 import InlineSelect from '../../components/InlineSelect'
 import { staggerContainer, staggerItem } from '../../lib/animations'
@@ -263,7 +264,7 @@ export default function SessionHistory() {
   const isLoading = sessionsLoading || statsLoading
 
   return (
-    <div>
+    <PageContainer>
       <PageHeader
         icon={<History size={20} />}
         title="Session History"
@@ -566,6 +567,6 @@ export default function SessionHistory() {
           </span>
         </div>
       )}
-    </div>
+    </PageContainer>
   )
 }

--- a/src/pages/portal/SettingsPage.tsx
+++ b/src/pages/portal/SettingsPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import { Link } from 'react-router-dom'
+import { PUBLIC_PATHS } from '../../constants/paths'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { motion } from 'framer-motion'
 import {
@@ -203,7 +204,7 @@ export default function SettingsPage() {
 
       {/* Team Directory shortcut */}
       <Link
-        to="/team"
+        to={PUBLIC_PATHS.publicTeam}
         className="inline-flex items-center gap-2 mb-4 px-4 py-2.5 rounded-lg border transition-colors hover:bg-black/5 dark:hover:bg-white/5"
         style={{
           borderColor: 'var(--border-subtle)',
@@ -386,7 +387,7 @@ export default function SettingsPage() {
             </p>
           </div>
           <Link
-            to="/team"
+            to={PUBLIC_PATHS.publicTeam}
             className="inline-flex items-center gap-2 px-4 py-2.5 rounded-lg border transition-colors hover:bg-black/5 dark:hover:bg-white/5"
             style={{
               borderColor: 'var(--border-subtle)',


### PR DESCRIPTION
## Summary

Layout-consistency pass on the portal. Half the portal pages rendered edge-to-edge while the other half were capped at 1440px and centered, so the content width *jumped* as you navigated between routes. This unifies the width contract and clears a few small consistency issues found along the way.

The site was already **functionally healthy** — build green, all routes wired, no orphaned pages, `aria-current` set, empty/loading states present. The fixes here are layout/hygiene only; no behavior change beyond page width.

## Changes

- **Shared page-width contract** — new `src/components/PageContainer.tsx` owning the single `.content-container` width/padding contract. Adopted as the page root on the 10 portal pages that previously had no max-width wrapper: Analytics, PIAnalytics, Activity, Search, AskTheLab, Narratives, MeetingNotes, SessionHistory, MenteeMilestones, DeadlineCascade.
  - **Deliberately left as-is:** the full-bleed operating surfaces (Today, MyTasks, Calendar, Personal) and the intentionally narrower PBSector planner (`max-w-6xl`).
- **CalendarPage mobile fix** — scoped the fixed cell heights (`min-h-[80px]` / `min-h-[300px]`) to `md:` so mobile uses intrinsic auto height (design rule 15).
- **Route hygiene** — replaced hardcoded route strings with `PATHS` / `PUBLIC_PATHS` constants in `ProfilePage` and `SettingsPage`.

## Verification

- `tsc --noEmit` clean (0 errors)
- `vite build` green (only the pre-existing three.js/Network chunk-size warning)
- All 10 `PageContainer` conversions confirmed balanced (one open/close/import each)

## Notes

- §4 of the plan (add empty states) was a no-op — ActivityPage and DeadlinesPage already have `EmptyState` components.
- Deploy is manual (`npm run deploy:pages:gated`) and was **not** run — this web container has no Cloudflare auth, and there is no auto-deploy CI. Deploy locally from `main` after merge.

https://claude.ai/code/session_018ZWTdkTpW1zvkZvbCGWTAA

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZWTdkTpW1zvkZvbCGWTAA)_